### PR TITLE
[기능 구현] 회원가입/로그인/로그아웃/마이페이지/calendarDay 등 정리

### DIFF
--- a/src/components/UI/Oraganisms/Header.tsx
+++ b/src/components/UI/Oraganisms/Header.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import { Col } from 'react-bootstrap';
+import { Link, useHistory } from 'react-router-dom';
+import { GiHamburgerMenu } from 'react-icons/gi';
 
 export default function Header() {
+  const handleSideBar = () => {
+    alert('sideBar Open?');
+  };
+
   return (
     <>
       <Col style={{ border: '1px solid black' }} xs={2} sm={1}>
-        hamburger button
+        <GiHamburgerMenu size="3em" onClick={handleSideBar} />
+        {/* 모양이 영 별로인데, 다른 방법을 찾아야 할 듯 */}
       </Col>
       <Col style={{ border: '1px solid black' }} xs={2}>
-        logo(main page link?)
+        <Link to="/">logo(main page link?)</Link>
       </Col>
       <Col style={{ border: '1px solid black' }} xs={2}>
         today button

--- a/src/components/UI/Oraganisms/UpdateUserInfoOrganism.tsx
+++ b/src/components/UI/Oraganisms/UpdateUserInfoOrganism.tsx
@@ -4,9 +4,13 @@ import { InputMolecule } from '../Molecules';
 
 interface UpdateUserInfoOrganismProps {
   handleChange(e: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement }): void;
+  currentNickname: string;
 }
 
-export default function UpdateUserInfoOrganism({ handleChange }: UpdateUserInfoOrganismProps) {
+export default function UpdateUserInfoOrganism({
+  handleChange,
+  currentNickname,
+}: UpdateUserInfoOrganismProps) {
   return (
     <Form className="px-5 py-3 m-auto" style={{ width: '400px', boxSizing: 'content-box' }}>
       <InputMolecule
@@ -14,7 +18,7 @@ export default function UpdateUserInfoOrganism({ handleChange }: UpdateUserInfoO
         controlId="formBasicEmail"
         type="text"
         name="nickname"
-        placeholder="현재 닉네임을 띄울 자리"
+        placeholder={currentNickname}
         handleChange={handleChange}
         smLabel={4}
         smInput={8}

--- a/src/components/templetes/Login.tsx
+++ b/src/components/templetes/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
 import axios from 'axios';
+import { RootState } from '../../modules';
 
 import { Container, Row, Col, Image, Form, Button } from 'react-bootstrap';
 import { BsFillAwardFill } from 'react-icons/bs';
@@ -31,6 +32,28 @@ export default function Login() {
 
   const dispatch = useDispatch();
   const history = useHistory();
+
+  /*  이미 로그인된 상태에서 /login에 접속하면 막아주는 장치인데, 
+      이 기능을 여기서 넣으니까 alert만 괜히 두번 뜬다
+      이 기능을 주지 않으면 로그인한 상태에서 /login에 접속이 가능해지므로, 처리하긴 해야 함
+
+      => 일단 로그인 버튼 자체를 안보이게 하자
+      => 그래도 주소 입력으로 접속하는 것은 막아야 하는데...
+
+    const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
+
+    if (currentUser) {
+      alert('이미 로그인이 되어 있습니다.');
+      history.push('/calendar/day');
+    }
+
+  */
+  const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
+
+  // if (currentUser) {
+  //   alert('이미 로그인이 되어 있습니다.');
+  //   history.push('/calendar/day');
+  // }
 
   const handleChange = (
     event: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement },
@@ -70,10 +93,13 @@ export default function Login() {
       )
       .then(res => {
         const { id, nickname, token } = res.data;
+        console.log('token : ', token);
         axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-
         dispatch(loginSuccess(id, nickname));
-        history.push('/');
+        // 토큰을 localStorage 등에 저장할 필요를 고려해야 할까?
+        localStorage.setItem('token', token); // 일단 저장해봄...
+        alert('로그인에 성공하셨습니다.');
+        history.push('/calendar/day');
       })
       .catch(err => {
         console.log(err);
@@ -124,7 +150,8 @@ export default function Login() {
       .then(res => {
         const { id, nickname, token } = res.data;
         axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-
+        // 토큰을 localStorage 등에 저장할 필요를 고려해야 할까?
+        localStorage.setItem('token', token); // 일단 저장해봄...
         dispatch(loginSuccess(id, nickname));
         history.push('/');
       })
@@ -148,7 +175,9 @@ export default function Login() {
         <Col className="m-auto" xs={10} sm={8} md={6}>
           {/* 고양이 이미지 */}
           <Col className="m-auto pb-3">
-            <Image src="img/cat.jpeg" height="171" width="180" roundedCircle />
+            <Link to="/">
+              <Image src="img/cat.jpeg" height="171" width="180" roundedCircle />
+            </Link>
           </Col>
 
           {/* 이메일 */}

--- a/src/components/templetes/MainContainer.tsx
+++ b/src/components/templetes/MainContainer.tsx
@@ -1,35 +1,50 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { Container, Row, Col, Button } from 'react-bootstrap';
 import { logout } from '../../modules/loginOut';
 import { RootState } from '../../modules';
+import axios from 'axios';
 
-function LogoutContainer() {
-  const state = useSelector(
-    (state: RootState) =>
-      // useSelector : redux store 안의 값들을 읽어온다. (selector function 을 전달하여, Context에 포함된 state 를 가져올 수 있다.)
-      state.loginOut, // reducer 함수를 넣어줘야 하는 듯
-    // [],
-  );
-}
+// function LogoutContainer() {
+//   const state = useSelector(
+//     (state: RootState) =>
+//       // useSelector : redux store 안의 값들을 읽어온다. (selector function 을 전달하여, Context에 포함된 state 를 가져올 수 있다.)
+//       state.loginOut, // reducer 함수를 넣어줘야 하는 듯
+//     // [],
+//   );
+// }
 
 // let currentUser = state.status.currentUser;
 
-// const history = useHistory();
-
-// const dispatch = useDispatch();
-
-// const handleLogout = () => {
-//   return axios.post(`${REACT_APP_URL}/users/logout`, {}, { withCredentials: true }).then(() => {
-//     dispatch(logout());
-//     alert('로그아웃되었습니다.');
-//     history.push('/');
-//   });
-// };
-
 // return <Header handleLogout={handleLogout} currentUser={currentUser} />;
 export default function MainContainer() {
+  const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
+
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  // if (currentUser) {
+  //   alert('이미 로그인이 되어 있습니다.');
+  //   history.push('/calendar/day');
+  // }
+
+  const handleLogout = () => {
+    if (!currentUser) {
+      alert('로그인이 되어있지 않습니다.');
+      return;
+    }
+    return axios
+      .post(`http://localhost:5000/users/logout`, {}, { withCredentials: true })
+      .then(() => {
+        dispatch(logout());
+        delete axios.defaults.headers.common['Authorization'];
+        localStorage.removeItem('token');
+        alert('로그아웃되었습니다.');
+        history.push('/');
+      });
+  };
+
   return (
     <>
       <Row className="py-3 m-0" style={{ border: '1px solid black' }}>
@@ -63,7 +78,7 @@ export default function MainContainer() {
               <Button size="lg">calendarDay</Button>
             </Link>
             <Link to="/">
-              <Button size="lg" onClick={LogoutContainer}>
+              <Button size="lg" onClick={handleLogout}>
                 logout
               </Button>
             </Link>

--- a/src/components/templetes/Mypage.tsx
+++ b/src/components/templetes/Mypage.tsx
@@ -26,11 +26,21 @@ export default function Mypage() {
   const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
 
   const userInfoState = useSelector((state: RootState) => state.handleUserInfo); // 끝에 [] 해줘야하는데 에러가 난다
+  // userInfo get 요청에 대응하는 API가 없으므로, 위 코드는 지금은 쓰이질 않고 있음
 
-  const loginState = useSelector((state: RootState) => state.loginOut);
+  const loginStatus = useSelector((state: RootState) => state.loginOut.status);
+  const currentUser = loginStatus.currentUser as number;
+  const currentNickname = loginStatus.nickname as string;
+  // 일단 이렇게 처리는 하는데, mypage의 userInfo get 요청을 통해 받아오는 nickname을 내려주도록 변경해야 한다.
+  // (userInfo get 요청에 대응하는 API를 서버에서 만들어주셔야 함)
 
   const history = useHistory();
   const dispatch = useDispatch();
+
+  if (!currentUser) {
+    alert('로그인하셔야 마이메이지에 접속하실 수 있습니다.');
+    history.push('./login');
+  }
 
   const handleChange = (
     e: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement },
@@ -67,12 +77,12 @@ export default function Mypage() {
         if (nickname.length > 0) {
           (document.querySelector('.nickname') as HTMLInputElement).value = '';
           // updateUserInfo(currentUser, nickname, null, null);
-          updateUserInfo('1', nickname, null, null);
+          updateUserInfo(currentUser, nickname, null, null);
         } else {
           (document.querySelector('.oldPassword') as HTMLInputElement).value = '';
           (document.querySelector('.newPassword') as HTMLInputElement).value = '';
           (document.querySelector('.newPasswordConfirm') as HTMLInputElement).value = '';
-          updateUserInfo('1', null, oldPassword, newPassword);
+          updateUserInfo(currentUser, null, oldPassword, newPassword);
         }
       }
     }
@@ -96,7 +106,7 @@ export default function Mypage() {
   };
 
   const updateUserInfo = (
-    currentUser: string,
+    currentUser: number,
     nickname: string | null,
     password: string | null,
     newPassword: string | null,
@@ -192,7 +202,7 @@ export default function Mypage() {
           아이콘 및 기본정보(?)
         </Row>
 
-        <UpdateUserInfoOrganism handleChange={handleChange} />
+        <UpdateUserInfoOrganism handleChange={handleChange} currentNickname={currentNickname} />
       </Container>
     </>
   );

--- a/src/components/templetes/Signup.tsx
+++ b/src/components/templetes/Signup.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, useState } from 'react';
 import ButtonBoot from '../UI/Atoms/ButtonBoot';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
+import { RootState } from '../../modules';
 
 import FormBoot from '../UI/Atoms/FormBoot';
 
@@ -19,6 +20,14 @@ export default function Signup() {
   const [passwordConfirm, setPasswordConfirm] = useState('');
 
   const dispatch = useDispatch();
+  const history = useHistory();
+
+  const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
+
+  if (currentUser) {
+    alert('로그인한 상태에서는 회원가입을 할 수 없습니다. 로그아웃 후 시도하세요');
+    history.push('/');
+  }
 
   const handleChange = (
     event: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement },
@@ -54,6 +63,7 @@ export default function Signup() {
       .then(res => {
         dispatch(signupSuccess());
         alert('환영합니다');
+        history.push('/login');
       })
       .catch(err => {
         alert(`잘못한거 같은데요!`);
@@ -85,7 +95,9 @@ export default function Signup() {
         <Col className="m-auto" xs={10} sm={8} md={6}>
           {/* 고양이 이미지 */}
           <Col className="m-auto pb-3">
-            <Image src="img/cat.jpeg" height="171" width="180" roundedCircle />
+            <Link to="/">
+              <Image src="img/cat.jpeg" height="171" width="180" roundedCircle />
+            </Link>
           </Col>
 
           {/* 이메일 */}


### PR DESCRIPTION
구현한 사항
  - 각 페이지의 상태에 따른 redirection들을 주로 수정함
  - 로그인 후 받아오는 token이 다음번의 req header에 잘 담기는지 확인했음
  - 로그아웃 기능 구현(req.header 삭제, 알람띄우기, redirection 등)

문제점
  - 로그인이 된 후에도 /login 주소를 입력하면 접속되지 않게 해야 하는데,
  - 알람을 하나 띄우고 싶은데 마음대로 되지 않음
  - alert 말고 modal로 하면 (새로고침이 없을테니) 괜찮을까? : 시도해 봐야 함