### PR TITLE
[수정] CalDeleteButton - 삭제를 위한 모달을 수정함

### DIFF
--- a/src/componentsNew/molecules/sidebar/SidebarMyCal.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarMyCal.tsx
@@ -17,7 +17,6 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
   const [newCalname, setNewCalname] = useState('');
   const [newCalcolor, setNewCalcolor] = useState('#0693e3');
   const { myCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
-  const [displayDeleteModal, setDisplayDeleteModal] = useState(false);
 
   const checked = (e: any) => {
     axios
@@ -45,6 +44,11 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
   };
 
   const addCalendar = () => {
+    if (newCalname === '') {
+      alert(`캘린더 이름이 입력되어 있지 않습니다.`);
+      return;
+    }
+
     axios
       .post(
         `http://localhost:5000/calendar/addcalendar`,
@@ -66,6 +70,7 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
   };
 
   const delCalendar = (calID: number) => {
+    console.log({ calID });
     if (typeof currentUser !== 'number') {
       alert('로그인 후 시도해 주세요.');
       return;
@@ -80,11 +85,11 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
         withCredentials: true,
       })
       .then(res => {
-        alert(`${res.data}`);
-        setDisplayDeleteModal(false);
+        console.log(`${calID}번 캘린더 삭제 요청의 결과 : `, res.data);
         setCalDeleted(true);
       })
       .catch(err => {
+        console.log({ err });
         alert(`${err}`);
       });
   };
@@ -106,13 +111,7 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
         addCalendar={addCalendar}
         currentColor={newCalcolor}
       />
-      <RenderCalendars
-        checked={checked}
-        calendars={myCalendar}
-        delCalendar={delCalendar}
-        displayDeleteModal={displayDeleteModal}
-        setDisplayDeleteModal={setDisplayDeleteModal}
-      />
+      <RenderCalendars checked={checked} calendars={myCalendar} delCalendar={delCalendar} />
     </SidebarMyCalWrap>
   );
 }

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalDeleteButton.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalDeleteButton.tsx
@@ -8,22 +8,13 @@ interface CalDeleteButtonProps {
   calId: number;
   calName: string;
   delCalendar: (calId: number) => void;
-  displayDeleteModal: boolean;
-  setDisplayDeleteModal: (trueOrFalse: boolean) => void;
 }
 
-export default function CalDeleteButton({
-  calId,
-  calName,
-  delCalendar,
-  displayDeleteModal,
-  setDisplayDeleteModal,
-}: CalDeleteButtonProps) {
+export default function CalDeleteButton({ calId, calName, delCalendar }: CalDeleteButtonProps) {
   const { myCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
+  const [displayDeleteModal, setDisplayDeleteModal] = useState(false);
 
-  const handleClose = () => {
-    setDisplayDeleteModal(false);
-  };
+  // console.log({ calId, calName });
 
   let DeleteModal;
 
@@ -33,7 +24,7 @@ export default function CalDeleteButton({
         <div>1개 남은 캘린더는 삭제할 수 없습니다</div>
         <div>새로운 캘린더를 먼저 만드신 뒤 삭제해 주세요.</div>
         <div style={{ marginTop: 'auto', marginLeft: 'auto' }}>
-          <button onClick={handleClose} style={{ margin: '5px' }}>
+          <button onClick={() => setDisplayDeleteModal(false)} style={{ margin: '5px' }}>
             확인
           </button>
         </div>
@@ -45,10 +36,19 @@ export default function CalDeleteButton({
         {' '}
         <div>'{calName}' 캘린더를 삭제하시겠습니까?</div>
         <div style={{ marginTop: 'auto', marginLeft: 'auto' }}>
-          <button onClick={() => delCalendar(calId)} style={{ margin: '5px' }}>
+          <button
+            onClick={() => {
+              delCalendar(calId);
+              setDisplayDeleteModal(false);
+              // then / catch 분기에 따라 다르게 처리하고 있지 않은데, 분기처리가 필요없다면 이렇게 마무리하면 됨
+              // 지금은 서버가 까져있어서 catch로 갔을 때, 'Error: Network Error' 라고 뜨고 모달이 꺼짐
+              // 다른 err가 뜨는 경우를 생각해 봐야 하지 않나?
+            }}
+            style={{ margin: '5px' }}
+          >
             삭제
           </button>
-          <button onClick={handleClose} style={{ margin: '5px' }}>
+          <button onClick={() => setDisplayDeleteModal(false)} style={{ margin: '5px' }}>
             취소
           </button>
         </div>
@@ -62,7 +62,7 @@ export default function CalDeleteButton({
         type="button"
         style={{ border: 'none', padding: '0px' }}
         onClick={() => {
-          setDisplayDeleteModal(!displayDeleteModal);
+          setDisplayDeleteModal(true);
         }}
       >
         <img src="/img/deleteIcon.png" alt="캘린더 삭제하기" width="23px" height="23px"></img>

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
@@ -11,17 +11,9 @@ interface RenderCalendarsProps {
     color: string;
   }>;
   delCalendar?: (calId: number) => void;
-  displayDeleteModal?: boolean;
-  setDisplayDeleteModal?: (trueOrFalse: boolean) => void;
 }
 // RenderCalendars : 체크박스 색깔 입히기 해야됨
-export default function RenderCalendars({
-  checked,
-  calendars,
-  delCalendar,
-  displayDeleteModal,
-  setDisplayDeleteModal,
-}: RenderCalendarsProps) {
+export default function RenderCalendars({ checked, calendars, delCalendar }: RenderCalendarsProps) {
   // console.log(calendars);
   let eachCalendars;
 
@@ -59,8 +51,6 @@ export default function RenderCalendars({
             calId={eachCalendar.id}
             calName={eachCalendar.name}
             delCalendar={delCalendar!}
-            displayDeleteModal={displayDeleteModal as boolean}
-            setDisplayDeleteModal={setDisplayDeleteModal!}
           />
         </div>
       );


### PR DESCRIPTION
## 첫번째 커밋
  - 캘린더가 1개 남은 상태에서 삭제하려고 하면, 삭제하지 못하도록 안내함
  - (새로운 캘린더를 추가한 뒤에는 기존 캘린더를 삭제할 수 있음)

---

## 두번째 커밋
[수정] CalDeleteButton 기능오류 해결 / addCalendar 기능 개선 

1. CalDeleteButton 기능오류 해결
    - CalDeleteButton의 모달창 상태를 상위 컴포넌트에 준 상태여서, 하나만 눌러도 모든 CalDeleteButton의 모달이 다 열리는 오류가 있었음
    - 그래서 어떤 캘린더의 삭제 버튼을 누르더라도 가장 밑의 캘린더의 삭제모달이 제일 위에 표시되고, 배경 역시 연회색 배경이 누적되며 색이 진해진 것
    - CalDeleteButton에서 모달창 상태를 직접 관리하도록 함 (기존에는 axios 요청이 있는 SidebarMyCal에서 관리했음)
    - 남은 문제점(?) : axios 요청이 실패하여 catch err로 가는 경우에 분기해 줄 필요가 있다면, 이 코드로는 불완전할 것임.

2. addCalendar 기능 개선
    - 새 캘린더의 이름이 입력되어 있지 않아도 캘린더가 추가되는 문제가 있었음
    - 남은 개선점(?) : 캘린더 이름의 글자 수를 제한해야 하지 않을까?