### PR TITLE
[수정] 캘린더를 삭제하면, handleCheckedCal 상태에 저장된 캘린더도 삭제

### DIFF
--- a/src/componentsNew/molecules/sidebar/SidebarMyCal.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarMyCal.tsx
@@ -1,9 +1,15 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import axios from 'axios';
 import styled from 'styled-components';
 import { RootState } from '../../../modules';
 import { MakeNewCal, RenderCalendars } from './sidebarCalUnits';
+import {
+  handleCheckedCalStart,
+  handleCheckedCalSuccess_add,
+  handleCheckedCalSuccess_del,
+  handleCheckedCalFailure,
+} from '../../../modules/handleCheckedCal';
 
 interface SidebarMyCalProps {
   setNewCalPosted: (trueOrFalse: boolean) => void;
@@ -17,6 +23,9 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
   const [newCalname, setNewCalname] = useState('');
   const [newCalcolor, setNewCalcolor] = useState('#0693e3');
   const { myCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
+  const { checkedCalArray } = useSelector((state: RootState) => state.handleCheckedCal);
+
+  const dispatch = useDispatch();
 
   const handleNewCalName = (
     e: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement },
@@ -71,6 +80,7 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
       .then(res => {
         console.log(`${calID}번 캘린더 삭제 요청의 결과 : `, res.data);
         setCalDeleted(true);
+        dispatch(handleCheckedCalSuccess_del(checkedCalArray.indexOf(calID)));
       })
       .catch(err => {
         console.log({ err });


### PR DESCRIPTION
  - 이 코드 없이도 todo 등은 잘 렌더링되겠지만, (받아올 todo들이 다 날아갔으므로)
  - handleCheckedCal 리덕스 상태에는 이미 삭제한 캘린더가 여전히 남아있게 된다.
  - 이런 점을 해결하기 위한 코드를 작성함