### PR TITLE
[오류 수정] MypageTags : tags가 빈 배열인 상태로 렌더링되는 문제 수정

### DIFF
--- a/src/componentsNew/molecules/sidebar/SidebarHeader.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarHeader.tsx
@@ -8,6 +8,7 @@ import axios from 'axios';
 
 import { handleTodaySuccess } from '../../../modules/handleToday';
 import { getCalendarsSuccess } from '../../../modules/getAllCalendars';
+import { handleTagsSuccess_Get } from '../../../modules/handleTags';
 import resetDayF from '../../utils/reSetDayF';
 import { ModalAlert, ModalChoice } from '../../atoms';
 import { GoogleLogout } from 'react-google-login';
@@ -30,6 +31,7 @@ export default function SidebarHeader() {
     dispatch(logout());
     dispatch(handleTodaySuccess(resetDayF()));
     dispatch(getCalendarsSuccess([], []));
+    dispatch(handleTagsSuccess_Get([]));
   };
 
   const handleLogout2 = () => {
@@ -94,6 +96,7 @@ export default function SidebarHeader() {
         dispatch(logout());
         dispatch(handleTodaySuccess(resetDayF()));
         dispatch(getCalendarsSuccess([], []));
+        dispatch(handleTagsSuccess_Get([]));
       })
       .catch(err => console.log({ err }));
   };

--- a/src/componentsNew/pages/MypageTags.tsx
+++ b/src/componentsNew/pages/MypageTags.tsx
@@ -8,12 +8,6 @@ import { PostNewTagBox, RenderTagsBox } from '../oraganisms/MypageTags';
 
 interface MypageTagsProps {
   userId: number;
-  tags: Array<{
-    id: number;
-    tagName: string;
-    tagColor: string;
-    description: string;
-  }>;
   postNewTag: (
     userId: number | null,
     tagColor: string,
@@ -30,13 +24,7 @@ interface MypageTagsProps {
   deleteTag: (userId: number, tagId: number) => void;
 }
 
-export default function MypageTags({
-  userId,
-  tags,
-  postNewTag,
-  updateTag,
-  deleteTag,
-}: MypageTagsProps) {
+export default function MypageTags({ userId, postNewTag, updateTag, deleteTag }: MypageTagsProps) {
   const searchTag = () => {};
   // 사이드바의 명칭을 더 명확히 하는게 좋을까?
 
@@ -45,7 +33,8 @@ export default function MypageTags({
     setShowPostNewTagBox(!showPostNewTagBox);
   };
 
-  console.log(tags);
+  const { tags } = useSelector((state: RootState) => state.handleTags);
+
   return (
     <div>
       <MainHeader>

--- a/src/container/MypageTagsContainer.tsx
+++ b/src/container/MypageTagsContainer.tsx
@@ -11,11 +11,8 @@ import MypageTags from '../componentsNew/pages/MypageTags';
 import { MypageHeaderAndSidebar } from '../componentsNew/oraganisms';
 import { ModalAlert } from '../componentsNew/atoms';
 
-import REACT_APP_URL from '../config';
-
 export default function MypageTagsContainer() {
   const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
-  const { tags } = useSelector((state: RootState) => state.handleTags);
 
   const [tagHandled, setTagHandled] = useState(false);
   const [handleModalAlert, setHandleModalAlert] = useState(false);
@@ -130,12 +127,11 @@ export default function MypageTagsContainer() {
   useEffect(() => {
     getAllTags();
     setTagHandled(false);
-  }, [tagHandled]);
+  }, [currentUser, tagHandled]);
 
   let childComponent = (
     <MypageTags
       userId={currentUser!}
-      tags={tags}
       postNewTag={postNewTag}
       updateTag={updateTag}
       deleteTag={deleteTag}

--- a/src/modules/handleTags.tsx
+++ b/src/modules/handleTags.tsx
@@ -7,12 +7,14 @@ const HANDLE_TAGS_FAILURE: string = 'HANDLE_TAGS_FAILURE';
 /* 2. 액션생성자 함수 : 액션 객체(action 객체의 type 값은 "HANDLE_TAGS_START" 등등)를 리턴합니다. */
 interface actionType {
   type: string;
-  tags: Array<{
-    id: number;
-    tagName: string;
-    tagColor: string;
-    description: string;
-  }>;
+  tags:
+    | Array<{
+        id: number;
+        tagName: string;
+        tagColor: string;
+        description: string;
+      }>
+    | [];
 }
 
 export function handleTagsStart() {
@@ -21,7 +23,9 @@ export function handleTagsStart() {
   };
 }
 
-export function handleTagsSuccess_Get(tags: actionType) {
+export function handleTagsSuccess_Get(
+  tags: { id: number; tagName: string; tagColor: string; description: string }[],
+) {
   return {
     type: HANDLE_TAGS_SUCCESS_GET,
     tags,
@@ -37,12 +41,14 @@ export function handleTagsFailure() {
 /* 3. initialState 및 reducer 함수 */
 interface initialStateI {
   status: string;
-  tags: Array<{
-    id: number;
-    tagName: string;
-    tagColor: string;
-    description: string;
-  }>;
+  tags:
+    | Array<{
+        id: number;
+        tagName: string;
+        tagColor: string;
+        description: string;
+      }>
+    | [];
 }
 
 const initialState: initialStateI = {


### PR DESCRIPTION
  - 기존 코드 : MypageTagsContainer에서 직접 useSelector로 'tags'를 받아 하위 컴포넌트에 내려줌
  - 문제점 : get요청이 redux에 저장되기 전에, 일단 비어었는 배열 상태로 렌더링이 먼저 실행됨
  - 개선 코드 : MypageTagsContainer에서는 get 요청만 내보내고, 'tags' 받아오는 부분은 하위의 MypageTags에서 useSelector 처리함
  - 추가 개선 : 로그아웃하면 tags를 빈 배열로 초기화함(SidebarOtherCal.tsx)