### PR TITLE
[기능 구현 (미완성)] SidebarTag / FilteredTodosAndReviews

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import MypageCalendarContainer from './container/MypageCalendarContainer';
 import SignupContainer from './container/SignupContainer';
 import LoginContainer from './container/LoginContainer';
 import CalendarDayContainer from './container/CalendarDayContainer';
+import FilteredTodosAndReviewsContainer from './container/FilteredTodosAndReviewsContainer';
 
 // import './App.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -29,6 +30,7 @@ function App() {
           <Route path="/mypage/calendar" component={MypageCalendarContainer} />
           <Route path="/login" component={LoginContainer} />
           <Route path="/calendar/day" component={CalendarDayContainer} />
+          <Route path="/filtered" component={FilteredTodosAndReviewsContainer} />
           <Route exact path="/" component={MainContainer} />
         </Switch>
       </Router>

--- a/src/componentsNew/molecules/sidebar/SidebarTag.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarTag.tsx
@@ -1,12 +1,55 @@
 import React, { useState } from 'react';
+import { Link, useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { RootState } from '../../../modules';
+
 import { Container, Row, Col, Modal, Button } from 'react-bootstrap';
 
 export default function SidebarTag() {
+  const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
+  const { tags } = useSelector((state: RootState) => state.handleTags);
+
+  /* 모달을 필요로 하실지도 모르니까, 일단 이하의 모달 코드를 남겨 둠 */
   const [smShow, setSmShow] = useState(false);
+
+  const history = useHistory();
+
+  const handleClickTagIcon = (tagId: number) => {
+    history.push('/filtered');
+    // 클릭한 tagId 를 기준으로 최초 필터링을 하고 싶은데, history.push로는 FilteredTodosAndReviews 컴포넌트에 영향을 줄 수가 없다.
+  };
+
+  let tagsList =
+    tags.length === 0 ? (
+      <Link to="/mypage/tags">태그를 먼저 만들어 주세요</Link>
+    ) : (
+      tags.map(eachTag => {
+        return (
+          <TagIcon
+            key={eachTag.id}
+            tagId={eachTag.id}
+            tagColor={eachTag.tagColor}
+            onClick={() => handleClickTagIcon(eachTag.id)}
+          >
+            {eachTag.tagName}
+          </TagIcon>
+        );
+      })
+    );
+
   return (
-    <Col className="m-3">
-      Tag
-      <Row onClick={() => setSmShow(true)}>tag 선택하기</Row>
+    <SidebarTagWrap className="SidebarTagWrap">
+      <div onClick={() => setSmShow(true)}>tag 선택하기</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>{tagsList}</div>
+      {/* 해야 할 일
+          - 일단 모든 태그 나열하기. (여기까지는 완성 : 1218)
+          - 나열된 태그를 클릭하면, 다른 화면으로 넘어가기.
+          - 이 별도의 화면에서는 클릭된 태그를 포함하는 모든 todo/review들이 날짜와 무관하게(순서대로?) 나열되어야 함.
+          - 또한, 그 안에서도 다른 태그들로 필터링이 다시 가능해야 하고, 그 안에서도 캘린더별 필터링도 가능해야 함.
+      */}
+      {/* ------------------------------------------------------------------------------------ */}
+      {/* 팀원 분들이 모달을 필요로 하실지도 모르니까, 일단 이하의 모달 코드를 남겨 둠 */}
       <Modal
         size="sm"
         show={smShow}
@@ -25,6 +68,26 @@ export default function SidebarTag() {
           <div>tag</div>
         </Modal.Body>
       </Modal>
-    </Col>
+      {/* ------------------------------------------------------------------------------------ */}
+    </SidebarTagWrap>
   );
 }
+
+const SidebarTagWrap = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 10px;
+  /* width 속성을 이렇게 줘야 좀 작게 나열된다. 숫자는 어느정도 이하이기만 하면 되고, 그 이상 넘어가면 이상해짐 */
+  /* 상위 컴포넌트에서 부트스트랩 코들르 지우고 넓이 지정을 제대로 해 주면 해결되지 않을까 생각함 */
+  border: 1px solid red;
+`;
+
+const TagIcon = styled.div<{ tagId: number; tagColor: string }>`
+  border-radius: 10px;
+  background-color: ${props => props.tagColor};
+  color: white;
+  font-weight: bold;
+  padding: 4px;
+  margin: 4px;
+`;

--- a/src/componentsNew/oraganisms/Sidebar.tsx
+++ b/src/componentsNew/oraganisms/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import styled from 'styled-components';
 import { Container, Row } from 'react-bootstrap';
 
 import {
@@ -21,21 +21,36 @@ export default function Sidebar({ setNewCalPosted, setCalDeleted }: SidebarProps
       <Row>
         <SidebarHeader></SidebarHeader>
       </Row>
+      <HrLine />
       <Row>
         <SidebarTag></SidebarTag>
       </Row>
+      <HrLine />
       <Row>
         <SidebarCal></SidebarCal>
       </Row>
+      <HrLine />
       <Row>
         <SidebarMyCal
           setNewCalPosted={setNewCalPosted}
           setCalDeleted={setCalDeleted}
         ></SidebarMyCal>
       </Row>
+      <HrLine />
       <Row>
         <SidebarOtherCal></SidebarOtherCal>
       </Row>
     </Container>
   );
 }
+
+const HrLine = styled.hr`
+  border: 0;
+  clear: both;
+  display: block;
+  width: 100%;
+  background-color: gray;
+  height: 1px;
+  margin: 5px 0px;
+  padding: 0px;
+`;

--- a/src/componentsNew/oraganisms/index.tsx
+++ b/src/componentsNew/oraganisms/index.tsx
@@ -2,8 +2,18 @@ import UserInfo from './UserInfo';
 import Header from './Header';
 import Todos from './Todos';
 import Reviews from './Reviews';
+import Sidebar from './Sidebar';
 import SignupSocial from './SignupSocial';
 import SignupGeneral from './SignupGeneral';
 import MypageHeaderAndSidebar from './MypageHeaderAndSidebar';
 
-export { UserInfo, Header, Todos, Reviews, SignupSocial, SignupGeneral, MypageHeaderAndSidebar };
+export {
+  UserInfo,
+  Header,
+  Todos,
+  Reviews,
+  Sidebar,
+  SignupSocial,
+  SignupGeneral,
+  MypageHeaderAndSidebar,
+};

--- a/src/componentsNew/pages/CalendarDay.tsx
+++ b/src/componentsNew/pages/CalendarDay.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { Row, Col, Container } from 'react-bootstrap';
 
-import { Header, Todos, Reviews } from '../oraganisms';
-import Sidebar from '../oraganisms/Sidebar';
+import { Header, Todos, Reviews, Sidebar } from '../oraganisms';
 
 import { todayProps } from '../../types';
 

--- a/src/componentsNew/pages/FilteredTodosAndReviews.tsx
+++ b/src/componentsNew/pages/FilteredTodosAndReviews.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Link, useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../modules';
+
+interface FilteredTodosAndReviewsProps {
+  tagId?: number;
+}
+
+export default function FilteredTodosAndReviews({ tagId }: FilteredTodosAndReviewsProps) {
+  const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
+  const { tags } = useSelector((state: RootState) => state.handleTags);
+  const [allTagsForFiltering, setAllTagsForFiltering] = useState<number[]>([]);
+  const [selectedTags, setSelectedTags] = useState<number[]>([]);
+
+  const history = useHistory();
+  if (typeof currentUser !== 'number') {
+    alert('먼저 로그인을 해 주세요.');
+    history.push('/login');
+  }
+
+  const handleClickTagIcon = (tagId: number) => {
+    if (allTagsForFiltering.indexOf(tagId) !== -1) {
+      let tagIdIndex = allTagsForFiltering.indexOf(tagId);
+      let delBefore = allTagsForFiltering.slice(0, tagIdIndex);
+      let delAfter = allTagsForFiltering.slice(tagIdIndex + 1);
+      setAllTagsForFiltering([...delBefore, ...delAfter]);
+    } else {
+      let newTagsForFiltering = allTagsForFiltering.slice();
+      setAllTagsForFiltering([...newTagsForFiltering, tagId]);
+    }
+    // 클릭할때마다 배열 안에 잘 들어오고 나가는 중임.
+    // 전체 todo/review에 대한 get 요청 api가 나오면, 이 allTagsForFiltering 배열에 맞춰서 필터링해서 렌더링하면 된다.
+  };
+
+  let allTagsList =
+    tags.length === 0 ? (
+      <Link to="/mypage/tags">태그를 먼저 만들어 주세요</Link>
+    ) : (
+      tags.map(eachTag => {
+        return (
+          <TagIcon
+            key={eachTag.id}
+            className={`TagIcon_${eachTag.id}`}
+            tagId={eachTag.id}
+            tagColor={eachTag.tagColor}
+            onClick={() => {
+              handleClickTagIcon(eachTag.id);
+            }}
+          >
+            {eachTag.tagName}
+          </TagIcon>
+        );
+      })
+    );
+
+  let selectedTagsList =
+    tags.length === 0 ? (
+      <span>아직 선택된 태그가 없습니다.</span>
+    ) : (
+      tags.map(eachTag => {
+        if (allTagsForFiltering.indexOf(eachTag.id) !== -1) {
+          return (
+            <TagIcon
+              key={eachTag.id}
+              className={`TagIcon_${eachTag.id}`}
+              tagId={eachTag.id}
+              tagColor={eachTag.tagColor}
+              onClick={() => {
+                handleClickTagIcon(eachTag.id);
+              }}
+            >
+              {eachTag.tagName}
+            </TagIcon>
+          );
+        }
+      })
+    );
+
+  useEffect(() => {
+    if (tagId) {
+      handleClickTagIcon(tagId);
+    }
+  }, [tagId]);
+
+  return (
+    <FilteredTodosAndReviewsWrap>
+      <FilteredTodosAndReviewsHeader></FilteredTodosAndReviewsHeader>
+      <FilteredTodosAndReviewsSidebar>
+        <SideBarTags>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            필터링할 태그를 선택해 주세요.
+          </div>
+          {/* <HrLine /> */}
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>{allTagsList}</div>
+          <HrLine />
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            현재 선택하신 태그들입니다.
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>{selectedTagsList}</div>
+        </SideBarTags>
+        <SideBarCalendars></SideBarCalendars>
+      </FilteredTodosAndReviewsSidebar>
+    </FilteredTodosAndReviewsWrap>
+  );
+}
+
+const FilteredTodosAndReviewsWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+`;
+
+const HrLine = styled.hr`
+  border: 0;
+  clear: both;
+  display: block;
+  width: 100%;
+  background-color: gray;
+  height: 1px;
+  margin: 10px 0px;
+`;
+
+const FilteredTodosAndReviewsHeader = styled.div`
+  display: flex;
+  border: 1px solid red;
+  width: 100%;
+  height: 100px;
+`;
+
+const FilteredTodosAndReviewsSidebar = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid black;
+  flex-basis: auto;
+  height: 100%;
+  width: 250px;
+`;
+
+const SideBarTags = styled.div`
+  flex: 1;
+  border: 1px solid blue;
+  width: 100%;
+  padding: 10px;
+`;
+
+const SideBarCalendars = styled.div`
+  flex: 1;
+  border: 1px solid blue;
+  width: 100%;
+  padding: 10px;
+`;
+
+const TagIcon = styled.div<{ tagId: number; tagColor: string }>`
+  border-radius: 10px;
+  background-color: ${props => props.tagColor};
+  color: white;
+  font-weight: bold;
+  padding: 4px;
+  margin: 4px;
+  box-shadow: 5px 5px 5px grey; // 클릭한 것만 이런 강조 효과를 주고 싶었는데,
+`;

--- a/src/container/CalendarDayContainer.tsx
+++ b/src/container/CalendarDayContainer.tsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { RootState } from '../modules';
 
 import { calendarStart, calendarSuccess, calendarFailure } from '../modules/calendarM';
+import { handleTagsStart, handleTagsSuccess_Get, handleTagsFailure } from '../modules/handleTags';
 import {
   getCalendarsStart,
   getCalendarsSuccess,
@@ -102,11 +103,32 @@ function CalendarDayContainer() {
         }
 
         dispatch(calendarSuccess(resTodo.reverse(), resReviews));
+        getAllTags();
       })
       .catch(err => {
         console.log(err);
         dispatch(calendarFailure());
         dispatch(getCalendarsFailure());
+      });
+  };
+
+  const getAllTags = () => {
+    dispatch(handleTagsStart());
+
+    axios
+      .get(`${REACT_APP_URL}/calendar/tags`, {
+        params: {
+          userId: currentUser,
+        },
+        withCredentials: true,
+      })
+      .then(res => {
+        const resTags = res.data.myTags;
+        dispatch(handleTagsSuccess_Get(resTags));
+      })
+      .catch(err => {
+        console.log({ err });
+        dispatch(handleTagsFailure());
       });
   };
 

--- a/src/container/FilteredTodosAndReviewsContainer.tsx
+++ b/src/container/FilteredTodosAndReviewsContainer.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import FilteredTodosAndReviews from '../componentsNew/pages/FilteredTodosAndReviews';
+
+export default function FilteredTodosAndReviewsContainer() {
+  return <FilteredTodosAndReviews></FilteredTodosAndReviews>;
+}

--- a/src/modules/handleTags.tsx
+++ b/src/modules/handleTags.tsx
@@ -7,14 +7,12 @@ const HANDLE_TAGS_FAILURE: string = 'HANDLE_TAGS_FAILURE';
 /* 2. 액션생성자 함수 : 액션 객체(action 객체의 type 값은 "HANDLE_TAGS_START" 등등)를 리턴합니다. */
 interface actionType {
   type: string;
-  tags:
-    | Array<{
-        id: number;
-        tagName: string;
-        tagColor: string;
-        description: string;
-      }>
-    | [];
+  tags: Array<{
+    id: number;
+    tagName: string;
+    tagColor: string;
+    description: string;
+  }>;
 }
 
 export function handleTagsStart() {
@@ -41,14 +39,12 @@ export function handleTagsFailure() {
 /* 3. initialState 및 reducer 함수 */
 interface initialStateI {
   status: string;
-  tags:
-    | Array<{
-        id: number;
-        tagName: string;
-        tagColor: string;
-        description: string;
-      }>
-    | [];
+  tags: Array<{
+    id: number;
+    tagName: string;
+    tagColor: string;
+    description: string;
+  }>;
 }
 
 const initialState: initialStateI = {


### PR DESCRIPTION
  - SidebarTag : 태그 목록들을 나열하고, 각각 태그를 클릭하면 FilteredTodosAndReviews로 넘어감.
    - 클릭한 tagId 를 기준으로 최초 필터링을 하고 싶은데, history.push로는 FilteredTodosAndReviews 컴포넌트에 영향을 줄 수가 없다.
    - 굉장히 큰(또는 전체 페이지를 차지하는) 모달을 띄우는 방법이 낫나? 이러면 가능할 것도 같음.
    - 'tag 선택하기' 글씨를 누르면 모달이 뜨는 코드는 그냥 두긴 했는데, 지울지에 관해서 얘기해봐야 함.

  - FilteredTodosAndReviews : 현재 가진 태그들을 나열하고, 그 태그들을 클릭하면 이를 기준으로 모든 todo/review를 필터링하는 페이지.
    - 선택한 태그들을 강조 표시하고 싶었는데, 어떻게 해야할지를 몰라서 그냥 별도 리스트를 만드는걸로 구현함.
    - 그러나, 모든 todo/review를 받아오는 api가 아직 없어서, 실제 필터링은 하지 못함.
    - 새로고침하면 필터링 결과가 해제되는데, redux로 관리해야 하는 것일까?
    
---

목표 및 달성 여부
  - (성공) 현재 존재하는 태그들을 사이드바에 다 나열하기 
  - (미완) 태그 설정창으로 가는 버튼 추가 (수정/삭제버튼은 필요없음)
  - (추가작업 필요) 나열된 태그들을 클릭하면 -> 별도의 페이지로 넘어가서 -> 그 태그에 해당하는 todo/review들을 나열하기 (검색 기능)
  - (추가작업 필요) 검색 결과창의 좌측에 태그목록을 다시 나열하고, 그 각 태그들을 클릭하면 다시 필터링이 되도록 함
  - (미완) 검색결과창의 각 todo/review를 누르면 해당 날짜의 calendarDay를 렌더링함(?)