### PR TITLE
[기능 구현] todo에 관하여 tag/calendar post/update 기능 구현

### DIFF
--- a/src/componentsNew/molecules/sidebar/SidebarHeader.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarHeader.tsx
@@ -150,7 +150,7 @@ export default function SidebarHeader() {
             onFailure={handleLogout}
           />
         </Col> */}
-        <Link to="/mypage">
+        <Link to="/mypage/profile">
           <Col>
             <Button>setting</Button>
           </Col>

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalSettingButton.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalSettingButton.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-export default function CalSettingButton() {
+interface CalSettingButtonProps {
+  eachCalendarName: string;
+}
+
+export default function CalSettingButton({ eachCalendarName }: CalSettingButtonProps) {
+  let url = `/mypage/calendar/${eachCalendarName}`;
   return (
     <div style={{ flex: 1 }}>
-      <Link to="/mypage/calendar">
+      <Link to={url}>
         <button type="button" style={{ border: 'none', padding: '0px' }}>
           <img src="/img/settingIcon.png" alt="캘린더 설정하기" width="23px" height="23px"></img>
         </button>

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
@@ -48,7 +48,7 @@ export default function RenderCalendars({ calendars, delCalendar }: RenderCalend
             eachCalendarName={eachCalendar.name}
             handleCheckBox={handleCheckBox}
           />
-          <CalSettingButton />
+          <CalSettingButton eachCalendarName={eachCalendar.name} />
           <CalDeleteButton
             calId={eachCalendar.id}
             calName={eachCalendar.name}

--- a/src/componentsNew/molecules/todos/EachTagForTodoModal.tsx
+++ b/src/componentsNew/molecules/todos/EachTagForTodoModal.tsx
@@ -1,65 +1,48 @@
 import React, { useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-
+// setNewArrayOfTagsId(defaultArrayOfTagsId)
 import { RootState } from '../../../modules';
-import {
-  handleCheckedTagsStart,
-  handleCheckedTagsSuccess_add,
-  handleCheckedTagsSuccess_del,
-  handleTagsFailure,
-} from '../../../modules/handleCheckedTags';
 
 interface EachTagForTodoModalProps {
   tagId: number;
   tagName: string;
   tagColor: string;
+  handleCheckedTags: (tagId: number, isChecked: boolean) => void;
+  alreadyChecked: boolean;
 }
 
 export default function EachTagForTodoModal({
   tagId,
   tagName,
   tagColor,
+  handleCheckedTags,
+  alreadyChecked,
 }: EachTagForTodoModalProps) {
-  const { checkedTagArray } = useSelector((state: RootState) => state.handleCheckedTags);
+  // const { checkedTagArray } = useSelector((state: RootState) => state.handleCheckedTags);
 
-  let isCheckedDefault;
-  if (checkedTagArray.indexOf(tagId) !== -1) {
-    isCheckedDefault = true;
-  } else {
-    isCheckedDefault = false;
-  }
-
-  const [isChecked, setIsChecked] = useState(isCheckedDefault);
-
-  const dispatch = useDispatch();
+  // PostTodoModal의 태그 상태는 모달이 새로 열릴때마다 초기화되므로,
+  // 태그가 체크되었는지 여부를 checkedTagArray에 연동할 필요가 없다.
+  const [isChecked, setIsChecked] = useState(alreadyChecked);
 
   const handleTagCheckChange = () => {
     setIsChecked(!isChecked);
-    handleCheckTags(tagId, !isChecked); // 아직 갱신이 적용되지 않은 상태에서 바로 실행되므로, 반전해서 반영한다
-  };
-
-  const handleCheckTags = (checkedTag: number, isChecked: boolean) => {
-    if (checkedTagArray.indexOf(checkedTag) === -1 && isChecked === true) {
-      dispatch(handleCheckedTagsStart());
-      dispatch(handleCheckedTagsSuccess_add(checkedTag));
-    } else {
-      dispatch(handleCheckedTagsStart());
-      dispatch(handleCheckedTagsSuccess_del(checkedTagArray.indexOf(checkedTag)));
-    }
+    handleCheckedTags(tagId, !alreadyChecked); // 아직 갱신이 적용되지 않은 상태에서 바로 실행되므로, 반전해서 반영한다
   };
 
   return (
-    <div className="EachTag" style={{ display: 'flex', alignItems: 'center', margin: '3px 0px' }}>
+    <div
+      className="EachTag"
+      onClick={() => handleTagCheckChange()}
+      style={{ display: 'flex', alignItems: 'center', margin: '3px 0px' }}
+    >
       <div style={{ flex: 1, marginLeft: '10px' }}>{!isChecked ? '' : <span>&#10003;</span>}</div>
-      <div style={{ flex: 7, display: 'flex' }} onClick={() => handleTagCheckChange()}>
+      <div style={{ flex: 7, display: 'flex' }}>
         <TagIcon tagColor={tagColor} isChecked={isChecked}>
           {tagName}
         </TagIcon>
       </div>
-      <div style={{ flex: 1, marginRight: '10px' }} onClick={() => setIsChecked(!isChecked)}>
-        {!isChecked ? '' : <span>&#10007;</span>}
-      </div>
+      <div style={{ flex: 1, marginRight: '10px' }}>{!isChecked ? '' : <span>&#10007;</span>}</div>
     </div>
   );
 }

--- a/src/componentsNew/oraganisms/Todos.tsx
+++ b/src/componentsNew/oraganisms/Todos.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../modules';
 import { Container, Row } from 'react-bootstrap';
@@ -27,14 +27,22 @@ export default function Todos({ setNewPosted, setTodoDeletedOrUpdated }: TodosPr
       todosList = '';
     } else {
       todosList = todos.map(todo => {
-        // 나중에 서버 수정하고 reverse 삭제?
-        // todoId 순서로 정렬하여 나열하기(수정필요)
+        let defaultArrayOfTagsId: number[] = [];
+
+        if (todo.todoTags[0].tag === null) {
+          defaultArrayOfTagsId = [];
+        } else {
+          for (let j = 0; j < todo.todoTags.length; j++) {
+            defaultArrayOfTagsId.push(todo.todoTags[j].tag.id);
+          }
+        }
 
         if (checkedCalArray.indexOf(todo.calendarId) !== -1) {
-          let title = todo.title as string;
-          let id = todo.id as number;
-          let calendarId = todo.calendarId as number;
+          let title = todo.title;
+          let id = todo.id;
+          let calendarId = todo.calendarId;
           let scheduleDate: scheduleDateType = JSON.parse(todo.scheduleDate);
+
           return (
             <Todo
               title={title}
@@ -42,6 +50,7 @@ export default function Todos({ setNewPosted, setTodoDeletedOrUpdated }: TodosPr
               key={id}
               calendarId={calendarId}
               scheduleDate={scheduleDate}
+              defaultArrayOfTagsId={defaultArrayOfTagsId}
               setTodoDeletedOrUpdated={setTodoDeletedOrUpdated}
             />
           );

--- a/src/container/CalendarDayContainer.tsx
+++ b/src/container/CalendarDayContainer.tsx
@@ -74,6 +74,8 @@ function CalendarDayContainer() {
       .then(res => {
         let { myCalendars, shareCalendars } = res.data;
         dispatch(getCalendarsSuccess(myCalendars, shareCalendars));
+
+        // myCalendars에 포함된 todo/review 처리
         console.log(myCalendars);
         let resTodo = new Array();
 
@@ -102,7 +104,11 @@ function CalendarDayContainer() {
           resReviews = resReviews.concat(myCalendars[j].reviews);
         }
 
-        dispatch(calendarSuccess(resTodo.reverse(), resReviews));
+        // shareCalendars에 포함된 todo/review 처리 (아직 shareCalendars가 완성되지 않아, 이 부분 코드 없음)
+
+        // (myCalendars, shareCalendars 처리하는 부분은 별도 함수로 빼놓는게 낫지 않나?)
+
+        dispatch(calendarSuccess(resTodo, resReviews));
         getAllTags();
       })
       .catch(err => {

--- a/src/container/MypageTagsContainer.tsx
+++ b/src/container/MypageTagsContainer.tsx
@@ -125,8 +125,7 @@ export default function MypageTagsContainer() {
       });
   };
 
-
-<!--   const childComponent = <MypageTags userId={currentUser} createTag={createTag} tags={tags} />; -->
+  // const childComponent = <MypageTags userId={currentUser} createTag={createTag} tags={tags} />;
 
   useEffect(() => {
     getAllTags();

--- a/src/modules/calendarM.tsx
+++ b/src/modules/calendarM.tsx
@@ -18,9 +18,12 @@ interface scheduleTimeI {
 interface calendarDayI {
   type: string;
   todos: Array<{
+    id: number;
     title: string;
     scheduleDate: string;
-    id: number;
+    todoTags: Array<{
+      tag: { id: number; tagName: string; tagColor: string; descrption: string };
+    }>;
     calendarId: number;
     calendarColor: string;
   }>;
@@ -61,9 +64,12 @@ export function calendarFailure() {
 
 interface todosAndReviewsI {
   todos: Array<{
+    id: number;
     title: string;
     scheduleDate: string;
-    id: number;
+    todoTags: Array<{
+      tag: { id: number; tagName: string; tagColor: string; descrption: string };
+    }>;
     calendarId: number;
     calendarColor: string;
   }>;

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -11,9 +11,8 @@ import sideBarM from './sideBarM';
 import getAllCalendars from './getAllCalendars';
 import handleTags from './handleTags';
 import handleCheckedCal from './handleCheckedCal';
-import handleCheckedTags from './handleCheckedTags';
+// import handleCheckedTags from './handleCheckedTags'; // 안쓰게 되어 주석처리함
 import handle_SideBarTag_defaultFilteringTag from './handle_SideBarTag_defaultFilteringTag';
-
 
 const persistConfig = {
   key: 'root',
@@ -31,7 +30,7 @@ const persistConfig = {
     'getAllCalendars',
     'handleTags',
     'handleCheckedCal',
-    'handleCheckedTags',
+    // 'handleCheckedTags',
     'handle_SideBarTag_defaultFilteringTag',
   ],
 
@@ -48,7 +47,7 @@ const reducers = combineReducers({
   getAllCalendars,
   handleTags,
   handleCheckedCal,
-  handleCheckedTags,
+  // handleCheckedTags,
   handle_SideBarTag_defaultFilteringTag,
 });
 


### PR DESCRIPTION
  - (1) 작성한 코드
    - PostTodoModal : tag 골라서 post 요청에 반영하기
    - Todo : tag 수정하기, calendar 수정하기
    - (추가 작성) 사이드바의 setting 버튼에 `/mypage/profile` 연결
    - (추가 작성) 사이드바의 내 캘린더 목록 설정버튼에 url을 `/mypage/calendar/${eachCalendarName}`으로 변경

  - (2) 개선 필요
    - 사이드바의 tag 필터링 기능을 PostTodoModal/Todo에도 넣으면 좋겠음
    - Todo 컴포넌트의 `select/option` 태그에서 `selected` 설정을 주면 콘솔에 에러가 찍히는 문제 있음(기능은 일단 작동함 / 질문 글 남길 것)
    - PostTodoModal / Todo 두 컴포넌트의 코드가 매우 지저분해졌음. 정리 필요