### PR TITLE
[기능 구현] FilteredTodosAndReviews 컴포넌트 수정

### DIFF
--- a/src/componentsNew/molecules/sidebar/SidebarHeader.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarHeader.tsx
@@ -129,7 +129,7 @@ export default function SidebarHeader() {
   return (
     <Col>
       <Row>
-        <Link to="/mypage">
+        <Link to="/mypage/profile">
           <Col className="m-auto pb-3">
             <Image src="/img/cat.jpeg" height="40" width="40" roundedCircle />
           </Col>

--- a/src/componentsNew/molecules/sidebar/SidebarTag.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarTag.tsx
@@ -6,10 +6,9 @@ import { RootState } from '../../../modules';
 import { Input } from '../../atoms';
 
 import {
-  handle_defaultfilteringTags_Start,
-  handle_defaultfilteringTags_Success,
-  handle_defaultfilteringTags_Failure,
-} from '../../../modules/handle_SideBarTag_defaultFilteringTag';
+  handle_first_filtering_on_sidebar_day_start,
+  handle_first_filtering_on_sidebar_day_success,
+} from '../../../modules/handle_TagsAndCalsArrayForFiltering';
 
 export default function SidebarTag() {
   const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
@@ -27,8 +26,8 @@ export default function SidebarTag() {
   const dispatch = useDispatch();
 
   const handleClickTagIcon = (tagId: number) => {
-    dispatch(handle_defaultfilteringTags_Start());
-    dispatch(handle_defaultfilteringTags_Success(tagId));
+    dispatch(handle_first_filtering_on_sidebar_day_start());
+    dispatch(handle_first_filtering_on_sidebar_day_success(tagId));
     history.push('/filtered');
 
     // 클릭한 tagId 를 기준으로 FilteredTodosAndReviews에서 최초 필터링을 하게 수정했음

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalCheckBox.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalCheckBox.tsx
@@ -7,6 +7,7 @@ interface CalCheckBoxProps {
   eachCalendarId: number;
   eachCalendarColor: string;
   eachCalendarName: string;
+  calArrayForFiltering: Array<number>;
   handleCheckBox: (checkedCal: number, isChecked: boolean) => void;
 }
 
@@ -24,12 +25,11 @@ export default function CalCheckBox({
   eachCalendarId,
   eachCalendarColor,
   eachCalendarName,
+  calArrayForFiltering,
   handleCheckBox,
 }: CalCheckBoxProps) {
-  const { checkedCalArray } = useSelector((state: RootState) => state.handleCheckedCal);
-
   let isCheckedDefault;
-  if (checkedCalArray.indexOf(eachCalendarId) !== -1) {
+  if (calArrayForFiltering.indexOf(eachCalendarId) !== -1) {
     isCheckedDefault = true;
   } else {
     isCheckedDefault = false;

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
@@ -46,6 +46,7 @@ export default function RenderCalendars({ calendars, delCalendar }: RenderCalend
             eachCalendarId={eachCalendar.id}
             eachCalendarColor={eachCalendar.color}
             eachCalendarName={eachCalendar.name}
+            calArrayForFiltering={checkedCalArray}
             handleCheckBox={handleCheckBox}
           />
           <CalSettingButton eachCalendarName={eachCalendar.name} />

--- a/src/componentsNew/molecules/todos/Todo.tsx
+++ b/src/componentsNew/molecules/todos/Todo.tsx
@@ -216,7 +216,7 @@ export default function Todo({
       tags.map(eachTag => {
         if (newArrayOfTagsId.indexOf(eachTag.id) !== -1) {
           return (
-            <TagIcon key={eachTag.id} tagColor={eachTag.tagColor}>
+            <TagIcon key={eachTag.id} tagId={eachTag.id} tagColor={eachTag.tagColor}>
               {eachTag.tagName}
             </TagIcon>
           );
@@ -370,8 +370,21 @@ export default function Todo({
   }
 
   return (
-    <div style={{ flex: 1, margin: '1px' }}>
-      <TodoWrap onClick={() => setDisplayFixOrDelTodoModal(true)}>title : {title}</TodoWrap>
+    <>
+      <TodoWrap onClick={() => setDisplayFixOrDelTodoModal(true)}>
+        <div style={{ display: 'flex', flex: 1, margin: '10px' }}>title : {title}</div>
+        <div
+          style={{
+            display: 'flex',
+            flex: 2,
+            justifyContent: 'flex-end',
+            flexWrap: 'wrap',
+            marginRight: '5px',
+          }}
+        >
+          {selectedTags}
+        </div>
+      </TodoWrap>
       {displayFixOrDelTodoModal ? (
         <FixOrDelTodoModalWrap
           style={{
@@ -384,13 +397,15 @@ export default function Todo({
           </FixOrDelTodoModalBackground>
         </FixOrDelTodoModalWrap>
       ) : null}
-    </div>
+    </>
   );
 }
 
 const TodoWrap = styled.div`
+  display: flex;
   width: 100%;
-  border: 1px solid black;
+  align-items: center;
+  justify-content: 'space-between';
 `;
 
 const FixOrDelTodoModalWrap = styled.div`
@@ -445,11 +460,12 @@ const TagSelectWindow = styled.div`
   padding: 5px;
 `;
 
-const TagIcon = styled.div<{ tagColor: string }>`
+const TagIcon = styled.div<{ tagId: number; tagColor: string }>`
   border-radius: 10px;
   background-color: ${props => props.tagColor};
   color: white;
   font-weight: bold;
   padding: 4px;
   margin: 4px;
+  box-shadow: 5px 5px 5px grey; // 클릭한 것만 이런 강조 효과를 주고 싶었는데,
 `;

--- a/src/componentsNew/oraganisms/FilteredTagsAndReviews/AllTagsListRendering.tsx
+++ b/src/componentsNew/oraganisms/FilteredTagsAndReviews/AllTagsListRendering.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../modules';
+
+interface AllTagsListRenderingProps {
+  handleClickTagIcon: (tagId: number) => void;
+}
+
+export default function AllTagsListRendering({ handleClickTagIcon }: AllTagsListRenderingProps) {
+  const { tags } = useSelector((state: RootState) => state.handleTags);
+
+  let allTagsList =
+    tags.length === 0 ? (
+      <Link to="/mypage/tags">태그를 먼저 만들어 주세요</Link>
+    ) : (
+      tags.map(eachTag => {
+        return (
+          <TagIcon
+            key={eachTag.id}
+            className={`TagIcon_${eachTag.id}`}
+            tagId={eachTag.id}
+            tagColor={eachTag.tagColor}
+            onClick={() => {
+              handleClickTagIcon(eachTag.id);
+            }}
+          >
+            {eachTag.tagName}
+          </TagIcon>
+        );
+      })
+    );
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        필터링할 태그를 선택해 주세요.
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>{allTagsList}</div>
+    </div>
+  );
+}
+
+const TagIcon = styled.div<{ tagId: number; tagColor: string }>`
+  border-radius: 10px;
+  background-color: ${props => props.tagColor};
+  color: white;
+  font-weight: bold;
+  padding: 4px;
+  margin: 4px;
+  box-shadow: 5px 5px 5px grey; // 클릭한 것만 이런 강조 효과를 주고 싶었는데,
+`;

--- a/src/componentsNew/oraganisms/FilteredTagsAndReviews/FliteredTodos.tsx
+++ b/src/componentsNew/oraganisms/FilteredTagsAndReviews/FliteredTodos.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../../../modules';
+import styled from 'styled-components';
+
+export default function FliteredTodos() {
+  const { filteredTodosAndReviews } = useSelector(
+    (state: RootState) => state.handle_filteredTodosAndReviews,
+  );
+  const { tags_ArrayForFiltering } = useSelector(
+    (state: RootState) => state.handle_TagsAndCalsArrayForFiltering,
+  );
+
+  let filteredtodosList =
+    filteredTodosAndReviews.length === 0
+      ? 'Tag가 없습니다. 먼저 Tag를 만들고, Todo에 등록해 보세요!'
+      : filteredTodosAndReviews.map(eachTagsResult => {
+          if (tags_ArrayForFiltering.indexOf(eachTagsResult.id) !== -1) {
+            let tagId = eachTagsResult.id;
+            let tagColor = eachTagsResult.tagColor;
+            let tagName = eachTagsResult.tagName;
+            let todosFilteredByTag = eachTagsResult.todoTags;
+            return (
+              <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '10px' }}>
+                <div style={{ display: 'flex' }}>
+                  <TagIcon key={tagId} tagId={tagId} tagColor={tagColor}>
+                    {tagName}
+                  </TagIcon>
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    marginLeft: '30px',
+                    marginRight: '30px',
+                  }}
+                >
+                  {todosFilteredByTag[0].todo === null
+                    ? '선택하신 Tag로 필터링된 Todo가 없습니다.'
+                    : todosFilteredByTag.map(eachTodo => {
+                        let eachTodoId = eachTodo.todo.id;
+                        let eachTodoTitle = eachTodo.todo.title;
+                        let eachTodoScheduleDate = JSON.parse(eachTodo.todo.scheduleDate);
+                        return (
+                          <FilteredTodos_byTags key={eachTodoId} tagId={eachTodoId}>
+                            <div style={{ display: 'flex', flex: 1, margin: '10px' }}>
+                              title : {eachTodoTitle}
+                            </div>
+                            <div style={{ display: 'flex', flex: 1, margin: '10px' }}>
+                              {`${eachTodoScheduleDate.year}년 ${eachTodoScheduleDate.month}월 ${eachTodoScheduleDate.day}일`}
+                            </div>
+                            <div style={{ display: 'flex', flex: 1, margin: '10px' }}>
+                              {`(서버 요청) todo 별로 캘린더아이디가 따라와야, 캘린더별 필터링 가능`}
+                            </div>
+                            <div
+                              style={{
+                                display: 'flex',
+                                flex: 2,
+                                justifyContent: 'flex-end',
+                                flexWrap: 'wrap',
+                              }}
+                            >
+                              {
+                                '(서버 요청) 여기에 이 투두가 가진 태그들을 나열하려면, 서버에서 투두별로 태그아이디들을 배열로 넘겨주던가 해야 함'
+                              }
+                            </div>
+                          </FilteredTodos_byTags>
+                        );
+                      })}
+                </div>
+              </div>
+            );
+          }
+        });
+
+  return <FliteredTodosWrap>{filteredtodosList}</FliteredTodosWrap>;
+}
+
+const FliteredTodosWrap = styled.div`
+  border: 1px solid red;
+  margin: 5px;
+`;
+
+// Tag별 개별 Todo들
+const FilteredTodos_byTags = styled.div<{ tagId: number }>`
+  border: 1px solid blue;
+  margin: 5px;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: 'space-between';
+`;
+
+const TagIcon = styled.div<{ tagId: number; tagColor: string }>`
+  border-radius: 10px;
+  background-color: ${props => props.tagColor};
+  color: white;
+  font-weight: bold;
+  padding: 4px;
+  margin: 4px;
+  box-shadow: 5px 5px 5px grey; // 클릭한 것만 이런 강조 효과를 주고 싶었는데,
+`;

--- a/src/componentsNew/oraganisms/FilteredTagsAndReviews/MyCalendarsForFiltering.tsx
+++ b/src/componentsNew/oraganisms/FilteredTagsAndReviews/MyCalendarsForFiltering.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../../../modules';
+import {
+  handle_cals_ArrayForFiltering_Starts,
+  handle_cals_ArrayForFiltering_Success_Add,
+  handle_cals_ArrayForFiltering_Success_Del,
+} from '../../../modules/handle_TagsAndCalsArrayForFiltering';
+
+import { CalCheckBox } from '../../molecules/sidebar/sidebarCalUnits';
+
+export default function MyCalendarsForFiltering() {
+  const { myCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
+  const { cals_ArrayForFiltering } = useSelector(
+    (state: RootState) => state.handle_TagsAndCalsArrayForFiltering,
+  );
+
+  const dispatch = useDispatch();
+
+  const handleCheckBox = (checkedCal: number, isChecked: boolean) => {
+    if (cals_ArrayForFiltering.indexOf(checkedCal) === -1 && isChecked === true) {
+      dispatch(handle_cals_ArrayForFiltering_Starts());
+      dispatch(handle_cals_ArrayForFiltering_Success_Add(checkedCal));
+    } else {
+      dispatch(handle_cals_ArrayForFiltering_Starts());
+      dispatch(
+        handle_cals_ArrayForFiltering_Success_Del(cals_ArrayForFiltering.indexOf(checkedCal)),
+      );
+    }
+  };
+
+  let eachCalendars =
+    myCalendar === []
+      ? ''
+      : myCalendar.map(eachCalendar => {
+          return (
+            <EachCalWrap key={eachCalendar.id}>
+              <CalCheckBox
+                eachCalendarId={eachCalendar.id}
+                eachCalendarColor={eachCalendar.color}
+                eachCalendarName={eachCalendar.name}
+                calArrayForFiltering={cals_ArrayForFiltering}
+                handleCheckBox={handleCheckBox}
+              />
+            </EachCalWrap>
+          );
+        });
+
+  return <div>{eachCalendars}</div>;
+}
+
+const EachCalWrap = styled.div`
+  flex: 1;
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: center;
+  padding-left: 10px;
+`;

--- a/src/componentsNew/oraganisms/FilteredTagsAndReviews/SelectedTagsListRendering.tsx
+++ b/src/componentsNew/oraganisms/FilteredTagsAndReviews/SelectedTagsListRendering.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../modules';
+
+interface SelectedTagsListRenderingProps {
+  handleClickTagIcon: (tagId: number) => void;
+}
+
+export default function SelectedTagsListRendering({
+  handleClickTagIcon,
+}: SelectedTagsListRenderingProps) {
+  const { tags } = useSelector((state: RootState) => state.handleTags);
+  const { tags_ArrayForFiltering } = useSelector(
+    (state: RootState) => state.handle_TagsAndCalsArrayForFiltering,
+  );
+
+  let selectedTagsList =
+    tags_ArrayForFiltering.length === 0 ||
+    (tags_ArrayForFiltering.length === 1 && tags_ArrayForFiltering[0] === undefined) ? (
+      <span>아직 선택된 태그가 없습니다.</span>
+    ) : (
+      tags.map(eachTag => {
+        if (tags_ArrayForFiltering.indexOf(eachTag.id) !== -1) {
+          return (
+            <TagIcon
+              key={eachTag.id}
+              className={`TagIcon_${eachTag.id}`}
+              tagId={eachTag.id}
+              tagColor={eachTag.tagColor}
+              onClick={() => {
+                handleClickTagIcon(eachTag.id);
+              }}
+            >
+              {eachTag.tagName}
+            </TagIcon>
+          );
+        }
+      })
+    );
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>현재 선택하신 태그들입니다.</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>{selectedTagsList}</div>
+    </div>
+  );
+}
+
+const TagIcon = styled.div<{ tagId: number; tagColor: string }>`
+  border-radius: 10px;
+  background-color: ${props => props.tagColor};
+  color: white;
+  font-weight: bold;
+  padding: 4px;
+  margin: 4px;
+  box-shadow: 5px 5px 5px grey; // 클릭한 것만 이런 강조 효과를 주고 싶었는데,
+`;

--- a/src/componentsNew/oraganisms/FilteredTagsAndReviews/index.tsx
+++ b/src/componentsNew/oraganisms/FilteredTagsAndReviews/index.tsx
@@ -1,0 +1,6 @@
+import FliteredTodos from './FliteredTodos';
+import MyCalendarsForFiltering from './MyCalendarsForFiltering';
+import AllTagsListRendering from './AllTagsListRendering';
+import SelectedTagsListRendering from './SelectedTagsListRendering';
+
+export { FliteredTodos, MyCalendarsForFiltering, AllTagsListRendering, SelectedTagsListRendering };

--- a/src/componentsNew/utils/sendReviewF.tsx
+++ b/src/componentsNew/utils/sendReviewF.tsx
@@ -28,6 +28,8 @@ export default function sendReview(
         scheduleDate: JSON.stringify(scheduleDate),
         scheduleTime: JSON.stringify(scheduleTime),
         calendarId,
+        tags: [5], // 서버에서 tags를 요청하도록 변경됐는데, 일단 임의의 배열(임의의 태그id를 담은 배열)로 넘김
+        // 실제로는 BigModal 안에서 태그를 선택(select/option)해서 '태그id들이 담긴 배열'로 만들어 매개변수로 넘길 수 있어야 한다.
       },
       { withCredentials: true },
     )

--- a/src/modules/handle_TagsAndCalsArrayForFiltering.tsx
+++ b/src/modules/handle_TagsAndCalsArrayForFiltering.tsx
@@ -1,0 +1,170 @@
+/* 1. ActionTypes - handle_TagsAndCalsArrayForFiltering */
+// API 통신이 필요한 상태관리가 아님
+const HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_START: string =
+  'HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_START';
+const HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_SUCCESS: string =
+  'HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_SUCCESS';
+const HANDLE_TAGS_ARRAY_FOR_FILTERING_STARTS: string = 'HANDLE_TAGS_ARRAY_FOR_FILTERING_STARTS';
+const HANDLE_CALS_ARRAY_FOR_FILTERING_STARTS: string = 'HANDLE_CALS_ARRAY_FOR_FILTERING_STARTS';
+const HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_ADD: string =
+  'HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_ADD';
+const HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_DEL: string =
+  'HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_DEL';
+const HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_ADD: string =
+  'HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_ADD';
+const HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_DEL: string =
+  'HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_DEL';
+
+const HANDLE_TAGS_AND_CALS_ARRAY_FAILURE: string = 'HANDLE_DEFAULT_FILTERING_TAGS_FAILURE';
+
+/* 2. 액션생성자 함수 : 액션 객체(action 객체의 type 값은 "HANDLE_TAGS_START" 등등)를 리턴합니다. */
+
+export function handle_first_filtering_on_sidebar_day_start() {
+  return {
+    type: HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_START,
+  };
+}
+
+export function handle_first_filtering_on_sidebar_day_success(tagId: number) {
+  return {
+    type: HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_SUCCESS,
+    tagId,
+  };
+}
+
+export function handle_tags_ArrayForFiltering_Starts() {
+  return {
+    type: HANDLE_TAGS_ARRAY_FOR_FILTERING_STARTS,
+  };
+}
+
+export function handle_tags_ArrayForFiltering_Success_Add(checkedTag: number) {
+  return {
+    type: HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_ADD,
+    checkedTag,
+  };
+}
+
+export function handle_tags_ArrayForFiltering_Success_Del(checkedTagIndex: number) {
+  return {
+    type: HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_DEL,
+    checkedTagIndex,
+  };
+}
+
+export function handle_cals_ArrayForFiltering_Starts() {
+  return {
+    type: HANDLE_CALS_ARRAY_FOR_FILTERING_STARTS,
+  };
+}
+
+export function handle_cals_ArrayForFiltering_Success_Add(checkedCal: number) {
+  return {
+    type: HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_ADD,
+    checkedCal,
+  };
+}
+
+export function handle_cals_ArrayForFiltering_Success_Del(checkedCalIndex: number) {
+  return {
+    type: HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_DEL,
+    checkedCalIndex,
+  };
+}
+
+export function handle_defaultfilteringTags_Failure() {
+  return {
+    type: HANDLE_TAGS_AND_CALS_ARRAY_FAILURE,
+  };
+}
+
+/* 3. initialState 및 reducer 함수 */
+interface initialStateI {
+  status: string;
+  tags_ArrayForFiltering: Array<number>;
+  cals_ArrayForFiltering: Array<number>;
+}
+
+const initialState: initialStateI = {
+  status: 'INIT',
+  tags_ArrayForFiltering: [],
+  cals_ArrayForFiltering: [],
+};
+
+/* reducer func*/
+
+interface actionType {
+  type: string;
+  tagId: number;
+  checkedTag: number;
+  checkedTagIndex: number;
+  checkedCal: number;
+  checkedCalIndex: number;
+}
+
+function handle_TagsAndCalsArrayForFiltering(state = initialState, action: actionType) {
+  switch (action.type) {
+    case HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_START:
+      return {
+        ...state,
+        status: 'START',
+      };
+    case HANDLE_FIRST_FILTERING_ON_SIDEBAR_DAY_SUCCESS:
+      return {
+        ...state,
+        status: 'SUCCESS',
+        tags_ArrayForFiltering: [action.tagId],
+      };
+
+    case HANDLE_TAGS_ARRAY_FOR_FILTERING_STARTS:
+      return {
+        ...state,
+        status: 'START',
+      };
+    case HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_ADD:
+      return {
+        ...state,
+        status: 'SUCCESS',
+        tags_ArrayForFiltering: [...state.tags_ArrayForFiltering, action.checkedTag],
+      };
+    case HANDLE_TAGS_ARRAY_FOR_FILTERING_SUCCESS_DEL:
+      let delTagBefore = state.tags_ArrayForFiltering.slice(0, action.checkedTagIndex);
+      let delTagAfter = state.tags_ArrayForFiltering.slice(action.checkedTagIndex + 1);
+      return {
+        ...state,
+        status: 'SUCCESS',
+        tags_ArrayForFiltering: [...delTagBefore, ...delTagAfter],
+      };
+
+    case HANDLE_CALS_ARRAY_FOR_FILTERING_STARTS:
+      return {
+        ...state,
+        status: 'START',
+      };
+    case HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_ADD:
+      return {
+        ...state,
+        status: 'SUCCESS',
+        cals_ArrayForFiltering: [...state.cals_ArrayForFiltering, action.checkedCal],
+      };
+    case HANDLE_CALS_ARRAY_FOR_FILTERING_SUCCESS_DEL:
+      let delCalBefore = state.cals_ArrayForFiltering.slice(0, action.checkedCalIndex);
+      let delCalAfter = state.cals_ArrayForFiltering.slice(action.checkedCalIndex + 1);
+      return {
+        ...state,
+        status: 'SUCCESS',
+        cals_ArrayForFiltering: [...delCalBefore, ...delCalAfter],
+      };
+
+    case HANDLE_TAGS_AND_CALS_ARRAY_FAILURE:
+      return {
+        ...state,
+        status: 'FAILURE',
+      };
+
+    default:
+      return state;
+  }
+}
+
+export default handle_TagsAndCalsArrayForFiltering;

--- a/src/modules/handle_filteredTodosAndReviews.tsx
+++ b/src/modules/handle_filteredTodosAndReviews.tsx
@@ -1,0 +1,92 @@
+/* 1. ActionTypes - handle default filtering Tags */
+const HANDLE_FILTERED_TODOS_AND_REVIEWS_STARTS: string = 'HANDLE_FILTERED_TODOS_AND_REVIEWS_START';
+const HANDLE_FILTERED_TODOS_AND_REVIEWS_SUCCESS: string = 'HANDLE_DEFAULT_FILTERING_TAGS_SUCCESS';
+const HANDLE_FILTERED_TODOS_AND_REVIEWS_FAILURE: string = 'HANDLE_DEFAULT_FILTERING_TAGS_FAILURE';
+
+/* 2. 액션생성자 함수 : 액션 객체(action 객체의 type 값은 "HANDLE_TAGS_START" 등등)를 리턴합니다. */
+
+export function handle_filteredTodosAndReviews_Start() {
+  return {
+    type: HANDLE_FILTERED_TODOS_AND_REVIEWS_STARTS,
+  };
+}
+
+export function handle_filteredTodosAndReviews_Success(filteredTodosAndReviews: number) {
+  return {
+    type: HANDLE_FILTERED_TODOS_AND_REVIEWS_SUCCESS,
+    filteredTodosAndReviews,
+  };
+}
+
+export function handle_filteredTodosAndReviews_Failure() {
+  return {
+    type: HANDLE_FILTERED_TODOS_AND_REVIEWS_FAILURE,
+  };
+}
+
+interface filteredTodosAndReviewsType {
+  id: number;
+  tagColor: string;
+  tagName: string;
+  todoTags: Array<{
+    todo: {
+      id: number;
+      scheduleDate: string;
+      title: string;
+    };
+  }>;
+  reviewTags: Array<{
+    review: {
+      id: number;
+      title: string;
+      context: string;
+      imageUrl: string;
+      scheduleDate: string;
+      scheduleTime: string;
+    };
+  }>;
+}
+
+/* 3. initialState 및 reducer 함수 */
+interface initialStateI {
+  status: string;
+  filteredTodosAndReviews: Array<filteredTodosAndReviewsType>;
+}
+
+const initialState: initialStateI = {
+  status: 'INIT',
+  filteredTodosAndReviews: [],
+};
+
+/* reducer func*/
+
+interface actionType {
+  type: string;
+  filteredTodosAndReviews: Array<filteredTodosAndReviewsType>;
+}
+
+function handlefilteredTodosAndReviews(state = initialState, action: actionType) {
+  switch (action.type) {
+    case HANDLE_FILTERED_TODOS_AND_REVIEWS_STARTS:
+      return {
+        ...state,
+        status: 'START',
+      };
+    case HANDLE_FILTERED_TODOS_AND_REVIEWS_SUCCESS:
+      return {
+        ...state,
+        status: 'SUCCESS',
+        filteredTodosAndReviews: action.filteredTodosAndReviews,
+      };
+    case HANDLE_FILTERED_TODOS_AND_REVIEWS_FAILURE:
+      return {
+        ...state,
+        status: 'FAILURE',
+      };
+
+    default:
+      return state;
+  }
+}
+
+export default handlefilteredTodosAndReviews;

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -13,6 +13,8 @@ import handleTags from './handleTags';
 import handleCheckedCal from './handleCheckedCal';
 // import handleCheckedTags from './handleCheckedTags'; // 안쓰게 되어 주석처리함
 import handle_SideBarTag_defaultFilteringTag from './handle_SideBarTag_defaultFilteringTag';
+import handle_filteredTodosAndReviews from './handle_filteredTodosAndReviews';
+import handle_TagsAndCalsArrayForFiltering from './handle_TagsAndCalsArrayForFiltering';
 
 const persistConfig = {
   key: 'root',
@@ -32,6 +34,8 @@ const persistConfig = {
     'handleCheckedCal',
     // 'handleCheckedTags',
     'handle_SideBarTag_defaultFilteringTag',
+    'handle_filteredTodosAndReviews',
+    'handle_TagsAndCalsArrayForFiltering',
   ],
 
   // blacklist -> 그것만 제외합니다(여기서는 적용하지 않았음)
@@ -49,6 +53,8 @@ const reducers = combineReducers({
   handleCheckedCal,
   // handleCheckedTags,
   handle_SideBarTag_defaultFilteringTag,
+  handle_filteredTodosAndReviews,
+  handle_TagsAndCalsArrayForFiltering,
 });
 
 export type RootState = ReturnType<typeof reducers>;


### PR DESCRIPTION
  - 작업내용
    - FilteredTodosAndReviews sidebar : tag / cal 모두 redux 상태관리 및 필터링 기능
    - FilteredTodosAndReviews main : todo 나열 및 필터링
    - 서버측에 '각 todo의 캘린더와 태그 정보' 추가 요청 필요함

  - 기타 추가 작업
    - bigmodal에서 태그아이디 없어서 post 안되는 문제 발견
    - day todo에서 태그 렌더링되도록 수정
    - day 사이드바에 고양이그림 링크 수정
    - day 사이드바에 태크 클릭시 사용될 리듀서 수정(기존 리듀서는 사용하지 않음)
    - 캘린더 렌더링을 위한 체크박스 부분(CalCheckBox)을 두군데(day sidebar/필터링 sidebar)서 사용하므로, 이에 맞게 코드 수정