### PR TITLE
[기능 구현] `FliteredTodos` 필터링 기능 보강

### DIFF
--- a/src/componentsNew/pages/FilteredTodosAndReviews.tsx
+++ b/src/componentsNew/pages/FilteredTodosAndReviews.tsx
@@ -88,6 +88,7 @@ export default function FilteredTodosAndReviews() {
           </SideBarTags>
           <HrLine />
           <SideBarCalendars>
+            필터링할 캘린더를 선택해 주세요.<br></br>
             내 캘린더
             <MyCalendarsForFiltering />
           </SideBarCalendars>
@@ -160,14 +161,14 @@ const FilteredTodosAndReviewsBody = styled.div`
 const FliteredReviews = styled.div``;
 
 const SideBarTags = styled.div`
-  flex: 1;
+  flex: 0 0 30%;
   border: 1px solid blue;
   width: 100%;
   padding: 10px;
 `;
 
 const SideBarCalendars = styled.div`
-  flex: 1;
+  /* flex: 1; */
   border: 1px solid blue;
   width: 100%;
   padding: 10px;

--- a/src/modules/handle_filteredTodosAndReviews.tsx
+++ b/src/modules/handle_filteredTodosAndReviews.tsx
@@ -33,6 +33,11 @@ interface filteredTodosAndReviewsType {
       id: number;
       scheduleDate: string;
       title: string;
+      calendar: {
+        id: number;
+        color: string;
+        name: string;
+      };
     };
   }>;
   reviewTags: Array<{


### PR DESCRIPTION
  - 작업 내용
    - 태그뿐만 아니라 캘린더에 따라서도 필터링하기 (이를 위해 `handlefilteredTodosAndReviews` 모듈을 수정했음)
    - 필터링된 todo를 클릭하면, 클릭한 todo의 캘린더만 체크되어 있도록 수정하면서 해당 날짜의 calendar day로 이동하기

  - 추가 작업 (없음)