### PR TITLE
[기능 구현] CalendarDayContainer / Todo 수정

### DIFF
--- a/src/componentsNew/molecules/todos/Todo.tsx
+++ b/src/componentsNew/molecules/todos/Todo.tsx
@@ -23,6 +23,14 @@ interface TodoProps {
   scheduleDate: scheduleDateType;
   defaultArrayOfTagsId: number[];
   setTodoDeletedOrUpdated: (todoDeleted: boolean) => void;
+  todoTags: Array<{
+    tag: {
+      id: number;
+      tagName: string;
+      tagColor: string;
+      description: string;
+    };
+  }>;
 }
 
 export default function Todo({
@@ -32,6 +40,7 @@ export default function Todo({
   scheduleDate,
   defaultArrayOfTagsId,
   setTodoDeletedOrUpdated,
+  todoTags,
 }: TodoProps) {
   const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
   const { tags } = useSelector((state: RootState) => state.handleTags);
@@ -142,13 +151,31 @@ export default function Todo({
     }
   };
 
+  // 내가 가진 tag는 모두 다 표시하고,
+  let concattedTagsArray = tags.slice();
+  let concattedTagsArrayId: Array<number> = [];
+
+  for (let j = 0; j < concattedTagsArray.length; j++) {
+    concattedTagsArrayId.push(concattedTagsArray[j].id);
+  }
+
+  // 공유받은 todo에 걸려있는 tag는, 내꺼는 중복되지 않게 필터링해서, 합친 tag 목록을 만듬
+  for (let i = 0; i < todoTags.length; i++) {
+    if (concattedTagsArrayId.indexOf(todoTags[i].tag.id) === -1) {
+      concattedTagsArray.push(todoTags[i].tag);
+    }
+  }
+
+  // todo를 수정할 때, 내 tag는 언제든 넣고 뺄 수 있지만,
+  // 공유받을 때 따라온 태그는, 내가 삭제해서 todo를 수정하면 다시 열어서는 붙일 수 없고,
+  // 공유해준 소유자한테 다시 태그를 붙여달라고 요청해야 함
   let tagsList =
-    tags.length === 0 ? (
+    concattedTagsArray.length === 0 ? (
       <span>
         <Link to="/mypage/tags">태그를 먼저 만들어 주세요</Link>
       </span>
     ) : (
-      tags.map(eachTag => {
+      concattedTagsArray.map(eachTag => {
         let alreadyChecked = newArrayOfTagsId.indexOf(eachTag.id) !== -1 ? true : false;
         return (
           <EachTagForTodoModal
@@ -213,11 +240,11 @@ export default function Todo({
       <span>(선택된 태그가 없습니다.)</span>
     ) : (
       // 추가/삭제를 해야 하니, tags와 비교할수밖에 없다.
-      tags.map(eachTag => {
-        if (newArrayOfTagsId.indexOf(eachTag.id) !== -1) {
+      todoTags.map(eachTag => {
+        if (newArrayOfTagsId.indexOf(eachTag.tag.id) !== -1) {
           return (
-            <TagIcon key={eachTag.id} tagId={eachTag.id} tagColor={eachTag.tagColor}>
-              {eachTag.tagName}
+            <TagIcon key={eachTag.tag.id} tagId={eachTag.tag.id} tagColor={eachTag.tag.tagColor}>
+              {eachTag.tag.tagName}
             </TagIcon>
           );
         }

--- a/src/componentsNew/oraganisms/Todos.tsx
+++ b/src/componentsNew/oraganisms/Todos.tsx
@@ -42,6 +42,7 @@ export default function Todos({ setNewPosted, setTodoDeletedOrUpdated }: TodosPr
           let id = todo.id;
           let calendarId = todo.calendarId;
           let scheduleDate: scheduleDateType = JSON.parse(todo.scheduleDate);
+          let todoTags = todo.todoTags;
 
           return (
             <Todo
@@ -52,6 +53,7 @@ export default function Todos({ setNewPosted, setTodoDeletedOrUpdated }: TodosPr
               scheduleDate={scheduleDate}
               defaultArrayOfTagsId={defaultArrayOfTagsId}
               setTodoDeletedOrUpdated={setTodoDeletedOrUpdated}
+              todoTags={todoTags}
             />
           );
         }

--- a/src/container/CalendarDayContainer.tsx
+++ b/src/container/CalendarDayContainer.tsx
@@ -88,6 +88,16 @@ function CalendarDayContainer() {
           resTodo = resTodo.concat(myCalendars[i].todos);
         }
 
+        for (let i in shareCalendars) {
+          let calendarId = shareCalendars[i].id;
+          let calendarColor = shareCalendars[i].color;
+          for (let ii = 0; ii < shareCalendars[i].todos.length; ii++) {
+            shareCalendars[i].todos[ii]['calendarId'] = calendarId;
+            shareCalendars[i].todos[ii]['calendarColor'] = calendarColor;
+          }
+          resTodo = resTodo.concat(shareCalendars[i].todos);
+        }
+
         let resReviews = new Array();
 
         for (let j in myCalendars) {
@@ -103,7 +113,18 @@ function CalendarDayContainer() {
           resReviews = resReviews.concat(myCalendars[j].reviews);
         }
 
-        // shareCalendars에 포함된 todo/review 처리 (아직 shareCalendars가 완성되지 않아, 이 부분 코드 없음)
+        for (let j in shareCalendars) {
+          let calendarId = shareCalendars[j].id;
+          let calendarColor = shareCalendars[j].color;
+          for (let jj = 0; jj < shareCalendars[j].reviews.length; jj++) {
+            let shortcut = shareCalendars[j].reviews[jj];
+            shortcut['calendarId'] = calendarId;
+            shortcut['calendarColor'] = calendarColor;
+            shortcut['scheduleDate'] = JSON.parse(shortcut['scheduleDate']);
+            shortcut['scheduleTime'] = JSON.parse(shortcut['scheduleTime']);
+          }
+          resReviews = resReviews.concat(shareCalendars[j].reviews);
+        }
 
         // (myCalendars, shareCalendars 처리하는 부분은 별도 함수로 빼놓는게 낫지 않나?)
 

--- a/src/container/SignupContainer.tsx
+++ b/src/container/SignupContainer.tsx
@@ -59,6 +59,7 @@ export default function SignupContainer() {
   };
 
   const handleRegister = (email: string, nickname: string, password: string) => {
+    console.log('여기는 한번만 와야 함');
     dispatch(signupStart());
 
     return axios

--- a/src/modules/calendarM.tsx
+++ b/src/modules/calendarM.tsx
@@ -22,7 +22,7 @@ interface calendarDayI {
     title: string;
     scheduleDate: string;
     todoTags: Array<{
-      tag: { id: number; tagName: string; tagColor: string; descrption: string };
+      tag: { id: number; tagName: string; tagColor: string; description: string };
     }>;
     calendarId: number;
     calendarColor: string;
@@ -68,7 +68,7 @@ interface todosAndReviewsI {
     title: string;
     scheduleDate: string;
     todoTags: Array<{
-      tag: { id: number; tagName: string; tagColor: string; descrption: string };
+      tag: { id: number; tagName: string; tagColor: string; description: string };
     }>;
     calendarId: number;
     calendarColor: string;


### PR DESCRIPTION
  - 작업내용
    - CalendarDayContainer: sharedCalendar 잘 오는지 확인하고, sendToday(get) 함수에서 필터링 수정
    - Todo : todo에서 렌더링되는 tag들을, '사용자가 갖고있는 모든 태그들'과 비교하지 말고, todo 안의 todoTags 배열만 갖고 렌더링하도록 수정 (공유받은 todo에서 태그가 나오지 않는 문제를 해결하기 위한 것)

  - 참고사항
    - 공유받은 Todo의 태그에 관하여, 이 Todo를 수정할 때 내 태그는 언제든지 모두 표시되나, 공유받은 태그는 이를 삭제하도록 todo를 수정하면, 다시 수정할 때에는 공유받은 태그를 붙일 수 없음
    - 공유받은 Todo의 태그에 관하여, 이들은 tag 기준 필터링하는 화면에서는 사용할 수 없고, 단지 공유받은 Todo에서 '어떤 태그가 달려있는지'를 보기만을 위한 것임
    - "공유받은 Todo에 걸려있는 태그들의 목록을 별도로 만들고 이를 기준으로도 필터링은 할 수 있게 해야되나?"