### PR TITLE
[수정] SidebarOtherCal / RenderCalendars

### DIFF
--- a/src/componentsNew/molecules/sidebar/SidebarMyCal.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarMyCal.tsx
@@ -99,14 +99,16 @@ export default function SidebarMyCal({ setNewCalPosted, setCalDeleted }: Sidebar
 
   return (
     <SidebarMyCalWrap>
-      <div>내 캘린더</div>
+      <div>My Calendars</div>
       <MakeNewCal
         handleNewCalName={handleNewCalName}
         handleNewCalColor={handleNewCalColor}
         addCalendar={addCalendar}
         currentColor={newCalcolor}
       />
-      <RenderCalendars calendars={myCalendar} delCalendar={delCalendar} />
+      <div style={{ display: 'flex', flexDirection: 'column', margin: '5px 0px', width: '100%' }}>
+        <RenderCalendars calendars={myCalendar} delCalendar={delCalendar} />
+      </div>
     </SidebarMyCalWrap>
   );
 }
@@ -118,4 +120,5 @@ const SidebarMyCalWrap = styled.div`
   justify-content: center;
   margin-top: 10px;
   margin-bottom: 10px;
+  width: 100%;
 `;

--- a/src/componentsNew/molecules/sidebar/SidebarSharedCal.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarSharedCal.tsx
@@ -1,16 +1,55 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../../modules';
-import { RenderCalendars } from './sidebarCalUnits';
+import { MakeNewCal, RenderCalendars } from './sidebarCalUnits';
+import axios from 'axios';
+import REACT_APP_URL from '../../../config';
 
-export default function SidebarSharedCal() {
+interface SidebarSharedCalProps {
+  setCalDeleted: (trueOrFalse: boolean) => void;
+}
+
+export default function SidebarSharedCal({ setCalDeleted }: SidebarSharedCalProps) {
+  const { currentUser } = useSelector((state: RootState) => state.loginOut.status);
   const { shareCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
+
+  const delCalendar = (calID: number) => {
+    console.log({ calID });
+    if (typeof currentUser !== 'number') {
+      alert('로그인 후 시도해 주세요.');
+      return;
+    }
+
+    // [궁금한 점] calendar day의 sidebar에 있는 '공유받은 캘린더들'에서, 휴지통 버튼에는 '캘린더 삭제'기능을 붙여야 할지, '공유받은걸 취소'하는걸 붙여야 할지 모르겠음.
+    // 아예 휴지통버튼 자체를 지우고 공유받은 캘린더는 설정창에서 컨트롤하는것도 좋아보임
+    // 일단은 console.log() 함수만 연결해 뒀음
+
+    // return axios
+    //   .delete(`${REACT_APP_URL}/calendar/deletecalendar`, {
+    //     data: {
+    //       userId: currentUser,
+    //       calendarId: calID,
+    //     },
+    //     withCredentials: true,
+    //   })
+    //   .then(res => {
+    //     console.log(`${calID}번 캘린더 삭제 요청의 결과 : `, res.data);
+    //     setCalDeleted(true);
+    //     dispatch(handleCheckedCalSuccess_del(checkedCalArray.indexOf(calID)));
+    //   })
+    //   .catch(err => {
+    //     console.log({ err });
+    //     alert(`${err}`);
+    //   });
+  };
 
   return (
     <SidebarSharedCalWrap>
-      <div>공유캘린더</div>
-      <RenderCalendars calendars={shareCalendar} />
+      <div>Shared Calendars</div>
+      <div style={{ display: 'flex', flexDirection: 'column', margin: '5px 0px', width: '100%' }}>
+        <RenderCalendars calendars={shareCalendar} delCalendar={delCalendar} />
+      </div>
     </SidebarSharedCalWrap>
   );
 }
@@ -22,4 +61,5 @@ const SidebarSharedCalWrap = styled.div`
   justify-content: center;
   margin-top: 10px;
   margin-bottom: 10px;
+  width: 100%;
 `;

--- a/src/componentsNew/molecules/sidebar/SidebarTag.tsx
+++ b/src/componentsNew/molecules/sidebar/SidebarTag.tsx
@@ -182,6 +182,7 @@ const SidebarTagWrap = styled.div`
   /* width 속성을 이렇게 줘야 좀 작게 나열된다. 숫자는 어느정도 이하이기만 하면 되고, 그 이상 넘어가면 이상해짐 */
   /* 상위 컴포넌트에서 부트스트랩 코들르 지우고 넓이 지정을 제대로 해 주면 해결되지 않을까 생각함 */
   border: 1px solid red;
+  margin: 5px 0px;
 `;
 
 const TagIcon = styled.div<{ tagId: number; tagColor: string }>`

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalDeleteButton.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/CalDeleteButton.tsx
@@ -16,6 +16,10 @@ export default function CalDeleteButton({ calId, calName, delCalendar }: CalDele
 
   // console.log({ calId, calName });
 
+  // [궁금한 점] calendar day의 sidebar에 있는 '공유받은 캘린더들'에서, 휴지통 버튼에는 '캘린더 삭제'기능을 붙여야 할지, '공유받은걸 취소'하는걸 붙여야 할지 모르겠음.
+  // 아예 휴지통버튼 자체를 지우고 공유받은 캘린더는 설정창에서 컨트롤하는것도 좋아보임
+  // 일단은 console.log() 함수만 연결해 뒀음
+
   let DeleteModal;
 
   if (myCalendar.length === 1) {

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/MakeNewCal.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/MakeNewCal.tsx
@@ -47,4 +47,5 @@ const MakeNewCalWrap = styled.div`
   /* flex-direction: column; */
   align-items: center;
   justify-content: center;
+  margin: 5px 0px;
 `;

--- a/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
+++ b/src/componentsNew/molecules/sidebar/sidebarCalUnits/RenderCalendars.tsx
@@ -16,7 +16,7 @@ interface RenderCalendarsProps {
     name: string;
     color: string;
   }>;
-  delCalendar?: (calId: number) => void;
+  delCalendar: (calId: number) => void;
 }
 
 export default function RenderCalendars({ calendars, delCalendar }: RenderCalendarsProps) {
@@ -63,14 +63,8 @@ export default function RenderCalendars({ calendars, delCalendar }: RenderCalend
   return <>{eachCalendars}</>;
 }
 
-interface RenderCalendarsWrapProps {
-  key: number;
-}
-
-const RenderCalendarsWrap = styled.div.attrs((props: RenderCalendarsWrapProps) => ({
-  key: props.key,
-}))`
-  flex: 1;
+const RenderCalendarsWrap = styled.div`
+  /* flex: 1; */
   display: flex;
   width: 100%;
   align-items: flex-start;

--- a/src/componentsNew/oraganisms/Sidebar.tsx
+++ b/src/componentsNew/oraganisms/Sidebar.tsx
@@ -38,7 +38,7 @@ export default function Sidebar({ setNewCalPosted, setCalDeleted }: SidebarProps
       </Row>
       <HrLine />
       <Row>
-        <SidebarSharedCal></SidebarSharedCal>
+        <SidebarSharedCal setCalDeleted={setCalDeleted}></SidebarSharedCal>
       </Row>
     </Container>
   );
@@ -50,7 +50,7 @@ const HrLine = styled.hr`
   display: block;
   width: 100%;
   background-color: gray;
-  height: 1px;
+  height: 3px;
   margin: 5px 0px;
   padding: 0px;
 `;


### PR DESCRIPTION
  - 작업 내용
    - SidebarOtherCal 이름 변경하고(SidebarSharedCal),
    - shareCalendar 받아서, todo들 필터링 및 렌더링하기 (기존 코드로 커버 가능했음)
    - SidebarOtherCal 안의 공유받은 캘린더들을 위해, delCalendar 함수 만들어주기

  - 궁금한 점
    - calendar day의 sidebar에 있는 '공유받은 캘린더들'에서, 휴지통 버튼에는 '캘린더 삭제'기능을 붙여야 할지, '공유받은걸 취소'하는걸 붙여야 할지 모르겠음.
    - 아예 휴지통버튼 자체를 지우고 공유받은 캘린더는 설정창에서 컨트롤하는것도 좋아보임
    - 일단은 console.log() 함수만 연결해 뒀음