### PR TITLE
[수정] PostTodoModal / MypageCalendar 수정

### DIFF
--- a/src/componentsNew/molecules/todos/PostTodoModal.tsx
+++ b/src/componentsNew/molecules/todos/PostTodoModal.tsx
@@ -23,6 +23,7 @@ export default function PostTodoModal({ showModal, closeModal, setNewPosted }: P
   const [title, setTitle] = useState('');
 
   const { myCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
+  const { shareCalendar } = useSelector((state: RootState) => state.getAllCalendars.allCalendars);
   const { tags } = useSelector((state: RootState) => state.handleTags);
   const [checkedTagArray, setCheckedTagArray] = useState<number[]>([]);
   const [selectedCalendar, setSelectedCalendar] = useState(NaN); // startDate : Date 객체 상태임
@@ -31,8 +32,8 @@ export default function PostTodoModal({ showModal, closeModal, setNewPosted }: P
   const [startDate, setStartDate] = useState(new Date(`${today.year} ${today.month} ${today.day}`)); // startDate : Date 객체 상태임
   const [showTagsSelectOptions, setShowTagsSelectOptions] = useState(false);
 
-  let defaultmyCalendersForSelectOptions = <option>클릭해서 선택해 주세요.</option>;
-  let myCalendersForSelectOptions = myCalendar.map(calendar => {
+  let defaultCalendersForSelectOptions = <option>클릭해서 선택해 주세요.</option>;
+  let calendersForSelectOptions = [...myCalendar, ...shareCalendar].map(calendar => {
     return (
       <option key={calendar.id} value={calendar.id}>
         {calendar.name}
@@ -195,7 +196,11 @@ export default function PostTodoModal({ showModal, closeModal, setNewPosted }: P
         setNewPosted(true); // 다시 렌더링하기 위해 상위 컴포넌트를 조작함(?)
       })
       .catch(err => {
-        alert(`${err}`);
+        if (err.response.data === '쓰기 권한 없음') {
+          alert(
+            `이 캘린더에서의 Todo 작성 권한을 보유하지 않고 있습니다. \r\n캘린더 설정 버튼을 눌러 권한을 확인하시거나, 다른 캘린더를 선택해 주세요.`,
+          );
+        }
       });
   };
 
@@ -244,8 +249,8 @@ export default function PostTodoModal({ showModal, closeModal, setNewPosted }: P
         <div style={{ flex: 1, margin: '5px' }}>
           <Label text="캘린더를 선택해 주세요." smLabel={1}></Label>
           <select className="selectedCalendar" onChange={handleSelectOption}>
-            {defaultmyCalendersForSelectOptions}
-            {myCalendersForSelectOptions}
+            {defaultCalendersForSelectOptions}
+            {calendersForSelectOptions}
           </select>
         </div>
         <div style={{ flex: 1, margin: '5px', position: 'relative' }}>

--- a/src/componentsNew/pages/MypageCalendar.tsx
+++ b/src/componentsNew/pages/MypageCalendar.tsx
@@ -81,6 +81,7 @@ export default function MypageCalendar({
       auth = true;
     }
     console.log({ select }, { read }, { write }, { auth });
+    console.log({ serchNickName });
     axios
       .post(
         `${REACT_APP_URL}/user/message`,
@@ -91,6 +92,8 @@ export default function MypageCalendar({
           write,
           auth,
           calendarId: curCalId,
+          otherNickname: serchNickName,
+          description: '',
         },
         { withCredentials: true },
       )


### PR DESCRIPTION
  - 작업내용
    - PostTodoModal : 내 캘린더들 뿐만 아니라 공유받은 캘린더들도 PostTodoModal에서 선택은 가능하도록 수정
    - PostTodoModal : 읽기 권한만 있고 쓰기 권한은 없는 공유캘린더의 경우, todo post요청시 권한이 없다는 err 메세지를 alert으로 표시
    - PostTodoModal : 읽기 권한과 쓰기 권한이 모두 있는 경우에는 Post/Put/Delete 모두 작동하는 것을 확인함
    - MypageCalendar : 캘린더 공유 message Post 요청이 안나가서, 서버 요구사항 참고하여 수정함
    - MypageCalendar 수정내용 : postMessage 함수에서 `otherNickname: serchNickName, description: '',` 내용 추가 (`SharedNickname: serchNickName,`은 수정되어야 하지 않나 싶음)