### PR TITLE
[수정] 캘린더 설정에서 이름/색상을 수정하면 즉시 반영되지 않던 문제를 수정함

### DIFF
--- a/src/componentsNew/pages/MypageCalendar.tsx
+++ b/src/componentsNew/pages/MypageCalendar.tsx
@@ -28,13 +28,13 @@ export default function MypageCalendar({
   //유저추가 모달
 
   const [handleModalDropbox, setHandleModalDropbox] = useState(false);
-  const [serchNickName, setSerchNickName] = useState('닉네임 검색');
+  const [searchNickName, setsearchNickName] = useState('닉네임 검색');
   const [dropboxDefaltValue, setDropboxDefaultValue] = useState('캘린더 보기');
-  // console.log('5번 닉네임 변경확인   :', serchNickName);
+  // console.log('5번 닉네임 변경확인   :', searchNickName);
 
   const handleCloseModal = () => {
     setHandleModalDropbox(false);
-    setSerchNickName('닉네임 검색');
+    setsearchNickName('닉네임 검색');
   };
   const openAddUserModal = () => {
     setHandleModalDropbox(true);
@@ -45,12 +45,12 @@ export default function MypageCalendar({
     setHandleModalDropbox(false);
   };
 
-  const serchUser = (serchNickName: string) => {
+  const searchUser = (searchNickName: string) => {
     axios
       .post(
         `${REACT_APP_URL}/user/isuser`,
         {
-          nickname: serchNickName,
+          nickname: searchNickName,
         },
         { withCredentials: true },
       )
@@ -58,7 +58,7 @@ export default function MypageCalendar({
         // console.log(res.data);
       })
       .catch(err => {
-        setSerchNickName('존재하지 않는 유저입니다.');
+        setsearchNickName('존재하지 않는 유저입니다.');
         console.log(err);
       });
   };
@@ -81,18 +81,18 @@ export default function MypageCalendar({
       auth = true;
     }
     console.log({ select }, { read }, { write }, { auth });
-    console.log({ serchNickName });
+    console.log({ searchNickName });
     axios
       .post(
         `${REACT_APP_URL}/user/message`,
         {
           userId: currentUser,
-          SharedNickname: serchNickName,
+          SharedNickname: searchNickName,
           read,
           write,
           auth,
           calendarId: curCalId,
-          otherNickname: serchNickName,
+          otherNickname: searchNickName,
           description: '',
         },
         { withCredentials: true },
@@ -114,11 +114,11 @@ export default function MypageCalendar({
       handleCloseModal={handleCloseModal}
       dropboxMenus={['캘린더 보기', '보기 & 편집', '보기 & 편집 & 공유']}
       dropboxDefaltValue={dropboxDefaltValue}
-      value={serchNickName}
+      value={searchNickName}
       handleChange={async (inputVal: string) => {
         // console.log('6번 :', inputVal, '최종전달지로 받음');
-        await setSerchNickName(inputVal);
-        await serchUser(inputVal);
+        await setsearchNickName(inputVal);
+        await searchUser(inputVal);
       }}
     />
   );

--- a/src/container/MypageCalendarContainer.tsx
+++ b/src/container/MypageCalendarContainer.tsx
@@ -12,6 +12,12 @@ import {
   getCalendarsSuccess,
   getCalendarsFailure,
 } from '../modules/getAllCalendars';
+import {
+  handle_rerenderCalendarDay_Start,
+  handle_rerenderCalendarDay_Success,
+  handle_rerenderCalendarDay_Failure,
+} from '../modules/handle_rerenderCalendarDay';
+
 import { ModalDropbox } from '../componentsNew/atoms';
 
 export default function MypageCalendarContainer({ match }: any) {
@@ -111,6 +117,7 @@ export default function MypageCalendarContainer({ match }: any) {
       .then(async res => {
         let { myCalendars, shareCalendars } = res.data;
         await dispatch(getCalendarsSuccess(myCalendars, shareCalendars));
+        dispatch(handle_rerenderCalendarDay_Success(true));
         // console.log('update redux success');
       })
       .catch(err => console.log(err));

--- a/src/container/MypageShareCalendar.tsx
+++ b/src/container/MypageShareCalendar.tsx
@@ -12,6 +12,11 @@ import {
   getCalendarsSuccess,
   getCalendarsFailure,
 } from '../modules/getAllCalendars';
+import {
+  handle_rerenderCalendarDay_Start,
+  handle_rerenderCalendarDay_Success,
+  handle_rerenderCalendarDay_Failure,
+} from '../modules/handle_rerenderCalendarDay';
 import { ModalDropbox } from '../componentsNew/atoms';
 
 export default function MypageCalendarContainer({ match }: any) {
@@ -102,7 +107,7 @@ export default function MypageCalendarContainer({ match }: any) {
       .then(async res => {
         let { myCalendars, shareCalendars } = res.data;
         await dispatch(getCalendarsSuccess(myCalendars, shareCalendars));
-        // console.log('update redux success');
+        dispatch(handle_rerenderCalendarDay_Success(true));
       })
       .catch(err => console.log(err));
   };


### PR DESCRIPTION
  - 작업내용
    - 대상 컴포넌트 : MypageCalendarContainer / MypageShareCalendar : `getUpdatedCal` 함수의 `then` 이하
    - 추가한 코드 : `dispatch(handle_rerenderCalendarDay_Success(true));`

---

  - 추가 작업 필요
    - MypageShareCalendar : 파일명과 컴포넌트명(함수명)이 다름
    - 내 캘린더와 수정권한 받은 공유캘린더는 수정 즉시 갱신이 잘 작동함
    - 수정권한이 없는 캘린더의 경우 `catch err`로 가는 것 같은데, 업데이트 후 get을 보내는 방식이기 때문에 aler을 잘못 걸면 문제가 될 듯
    - 그래서, 수정권한이 없는 캘린더는 수정 창 자체가 안열리게 하는 편이 좋지 않을까 생각했음