### PR TITLE
[기능 구현] CalendarDay / ToastMessage : toast 알람 기능

### DIFF
--- a/src/componentsNew/molecules/ToastMessage.tsx
+++ b/src/componentsNew/molecules/ToastMessage.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import styled, { css, keyframes } from 'styled-components';
+import { useHistory } from 'react-router-dom';
+
+interface ToastMessageProps {
+  eachMessageId: number;
+  fromUserNickname: string;
+  shareCalendarName: string;
+  bottom: number;
+}
+
+export default function ToastMessage({
+  eachMessageId,
+  fromUserNickname,
+  shareCalendarName,
+  bottom,
+}: ToastMessageProps) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  const history = useHistory();
+
+  return (
+    <ToastMessageWrap isVisible={isVisible} bottom={bottom}>
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          width: '100%',
+        }}
+      >
+        {fromUserNickname} 님께서
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          width: '100%',
+        }}
+      >
+        &nbsp;&nbsp;{shareCalendarName} 캘린더를 공유하셨습니다.
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          width: '100%',
+          marginTop: '5px',
+        }}
+      >
+        <button style={{ marginLeft: '5px' }} onClick={() => history.push('/mypage/calendar')}>
+          캘린더 확인
+        </button>
+        <button
+          style={{ marginLeft: '5px' }}
+          onClick={() => {
+            setIsVisible(false);
+          }}
+        >
+          닫기
+        </button>
+      </div>
+    </ToastMessageWrap>
+  );
+}
+
+const ToastMessageWrap = styled.div<{ isVisible: boolean; bottom: number }>`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  width: 300px;
+  height: 100px;
+  background-color: #333;
+  color: #fff;
+  border-radius: 5px;
+  margin: 5px;
+  padding: 10px;
+
+  position: fixed;
+  right: 30px;
+  bottom: ${props => `${props.bottom}px`};
+  z-index: 1;
+
+  -webkit-animation: ${props =>
+    props.isVisible
+      ? css`
+          ${fadeIn} 0.5s linear
+        `
+      : css`
+          ${fadeOut} 0.5s linear
+        `};
+  animation: ${props =>
+    props.isVisible
+      ? css`
+          ${fadeIn} 0.5s linear
+        `
+      : css`
+          ${fadeOut} 0.5s linear
+        `};
+  visibility: ${props => (props.isVisible ? 'visible' : 'hidden')};
+  transition: visibility 0.5s linear;
+`;
+
+// https://styled-components.com/docs/api#css
+// https://styled-components.com/docs/api#keyframes
+
+const fadeIn = keyframes`
+  from {
+    /* bottom: 0px; */
+    right: 0px;
+    opacity: 0;
+  }
+  to {
+    /* bottom: 30px; */
+    right: 30px;
+    opacity: 1;
+  }
+`;
+
+const fadeOut = keyframes`
+  from {
+    /* bottom: 30px; */
+    right: 30px;
+    opacity: 1;
+  }
+  to {
+    /* bottom: 0px; */
+    right: 60px;
+    opacity: 0;
+  }
+`;

--- a/src/componentsNew/molecules/index.tsx
+++ b/src/componentsNew/molecules/index.tsx
@@ -1,3 +1,4 @@
 import InputMolecule from './InputMolecule';
+import ToastMessage from './ToastMessage';
 
-export { InputMolecule };
+export { InputMolecule, ToastMessage };

--- a/src/componentsNew/molecules/todos/PostTodoModal.tsx
+++ b/src/componentsNew/molecules/todos/PostTodoModal.tsx
@@ -292,7 +292,7 @@ export default function PostTodoModal({ showModal, closeModal, setNewPosted }: P
 
 const PostTodoModalWrap = styled.div`
   position: 'absolute';
-  z-index: 1;
+  z-index: 2;
 `;
 
 const PostTodoModalBackground = styled.div`

--- a/src/componentsNew/pages/CalendarDay.tsx
+++ b/src/componentsNew/pages/CalendarDay.tsx
@@ -1,8 +1,12 @@
 // Todos, Reviews, Sidebar, Header
 import React from 'react';
+import styled, { css, keyframes } from 'styled-components';
 import { Row, Col, Container } from 'react-bootstrap';
 
+import { useSelector } from 'react-redux';
+import { RootState } from '../../modules';
 import { Header, Todos, Reviews, Sidebar } from '../oraganisms';
+import { ToastMessage } from '../molecules';
 
 import { todayProps } from '../../types';
 
@@ -15,6 +19,18 @@ interface CalendarDayProps {
   setTodoDeletedOrUpdated: (trueOrFalse: boolean) => void;
 }
 
+interface toastType {
+  id: number;
+  fromUser: number;
+  fromUserNickname: string;
+  shareCalendarName: string;
+  read: boolean;
+  write: boolean;
+  auth: boolean;
+  shareCalendar: number;
+  description: string;
+}
+
 export default function CalendarDay({
   sidebar,
   today,
@@ -23,7 +39,20 @@ export default function CalendarDay({
   setCalDeleted,
   setTodoDeletedOrUpdated,
 }: CalendarDayProps) {
-  // console.log('calendarDay');
+  const { messages } = useSelector((state: RootState) => state.mypageCalendarMessagesM);
+
+  let toastsList = messages.map((eachMessage: toastType, index: number) => {
+    return (
+      <ToastMessage
+        key={eachMessage.id}
+        eachMessageId={eachMessage.id}
+        fromUserNickname={eachMessage.fromUserNickname}
+        shareCalendarName={eachMessage.shareCalendarName}
+        bottom={index * 110 + 30}
+      />
+    );
+  });
+
   return (
     <Container fluid style={{ border: '1px solid black' }}>
       <Row>
@@ -52,6 +81,7 @@ export default function CalendarDay({
           </Row>
         </Col>
       </Row>
+      {toastsList}
     </Container>
   );
 }

--- a/src/container/CalendarDayContainer.tsx
+++ b/src/container/CalendarDayContainer.tsx
@@ -13,11 +13,20 @@ import {
   getCalendarsFailure,
 } from '../modules/getAllCalendars';
 import { handleTodaySuccess } from '../modules/handleToday';
+import { mypageCalendarMessageSuccess } from '../modules/mypageCalendarMessagesM';
 import getToday from '../componentsNew/utils/todayF';
 import CalendarDay from '../componentsNew/pages/CalendarDay';
 import REACT_APP_URL from '../config';
 
 // import date from '../componentsNew/utils/todayF';
+
+interface todayType {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  min: number;
+}
 
 function CalendarDayContainer() {
   //userId,오늘 날짜를 서버로 보내야함
@@ -43,13 +52,28 @@ function CalendarDayContainer() {
     history.push('../login');
   }
 
-  interface todayType {
-    year: number;
-    month: number;
-    day: number;
-    hour: number;
-    min: number;
-  }
+  // toast 알람을 위해, 캘린더 공유를 위한 message를 여기서 get 요청
+  const getCalShareMessage = () => {
+    axios
+      .get(`${REACT_APP_URL}/user/message`, {
+        params: {
+          userId: currentUser,
+        },
+        withCredentials: true,
+      })
+      .then(res => {
+        const { myMessages } = res.data;
+        //state를 쓰니 무한 반복됨. shareCalMessage 변수명을 같게 해주어서 무한 반복되는 것이었음.
+        //캘린더의 상태값을 다양한 곳에서 필요로 할 것 같아서 리덕스 사용
+        dispatch(mypageCalendarMessageSuccess(myMessages));
+      })
+      .catch(err => {
+        //메세지가 없는 경우
+        console.log(err);
+      });
+  };
+
+  getCalShareMessage();
 
   const sendToday = (id: number | null, today: todayType) => {
     dispatch(calendarStart());


### PR DESCRIPTION
  - 작업 내용
    - 캘린더를 공유받을 때 캘린더 설정창에 일부러 들어가지 않으면 공유가 왔다는 사실 자체를 알기 어려움
    - 그래서 가장 자주 보고 있을 CalendarDay 화면에서, 캘린더 공유가 들어왔다는 사실을 toast 알람으로 보여주는 것이 의미있을 것임
    - CalendarDayContainer : toast 알람을 위해, 캘린더 공유를 위한 message를 여기서 get 요청
    - CalendarDay : CalendarDayContainer에서 받아온 message를 map해서 ToastMessage들을 렌더링
    - ToastMessage : toast 알람 창 구성
---
  - 추가 수정 내용
    - PostTodoModal : ToastMessage가 z-index를 똑같이 1 가지고 있어 같은 레벨에 표시되므로, PostTodoModal의 z-index를 2로 올림
---
  - 관련하여 블로그 올림 / 기술발표 주제 예정